### PR TITLE
feat: agent-first frontend with class-specific dashboards

### DIFF
--- a/sidecars/browser-headless/server.mjs
+++ b/sidecars/browser-headless/server.mjs
@@ -538,10 +538,9 @@ async function bootstrapXSession(session, request, timeoutMs) {
   await page.waitForTimeout(4000);
   const auth = await xAuthState(page, stepTimeout);
   if (!auth.authenticated) {
-    const imported = await importXSessionFromChrome(session, stepTimeout).catch(() => null);
-    if (imported?.authenticated) {
-      return imported;
-    }
+    // Do NOT fall back to importXSessionFromChrome here. bootstrapXSession is called with
+    // explicit credentials (username, password, email are required above). Silently loading
+    // system Chrome cookies when headless login fails would authenticate as the wrong account.
     if (auth.status === 'suspicious_login_prevented') {
       throw new Error(
         `X blocked true headless login as suspicious activity. Final URL: ${auth.url}. Body: ${JSON.stringify(auth.bodySnippet)}`

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -2958,6 +2958,7 @@ pub(crate) fn build_tool_instructions(tools_registry: &[Box<dyn Tool>]) -> Strin
     let mut instructions = String::new();
     let has_mail = tools_registry.iter().any(|tool| tool.name() == "mail");
     let has_twitter_x = tools_registry.iter().any(|tool| tool.name() == "twitter_x");
+    let has_linkedin = tools_registry.iter().any(|tool| tool.name() == "linkedin");
     let has_browser = tools_registry.iter().any(|tool| tool.name() == "browser");
     let has_browser_headless = tools_registry
         .iter()
@@ -3003,6 +3004,13 @@ pub(crate) fn build_tool_instructions(tools_registry: &[Box<dyn Tool>]) -> Strin
         instructions.push_str("### X/Twitter Rule\n\n");
         instructions.push_str(
             "For X/Twitter tasks, use `twitter_x` first when it can complete the requested action. Prefer `browser_headless` or `browser_ext` only for flows that `twitter_x` cannot handle, for proof capture, or when the user explicitly wants browser automation.\n\n",
+        );
+    }
+
+    if has_linkedin {
+        instructions.push_str("### LinkedIn Rule\n\n");
+        instructions.push_str(
+            "For LinkedIn tasks, use the `linkedin` tool for posting, commenting, profile lookup, and feed retrieval. Use `agent_name` to select a specific LinkedIn account when multiple are configured.\n\n",
         );
     }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -354,11 +354,41 @@ pub struct SocialTwitterCredentials {
     pub email: Option<String>,
 }
 
+/// Platform-agnostic social account credentials.
+///
+/// Supports any social platform (X/Twitter, LinkedIn, etc.) via the `platform`
+/// discriminator. Stored in the `accounts` map of [`AgentSocialAccountsConfig`].
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct SocialAccountConfig {
+    /// Platform identifier: "twitter", "linkedin", etc.
+    pub platform: String,
+    /// Display label for this account (e.g. "company-x", "personal-linkedin").
+    #[serde(default)]
+    pub label: Option<String>,
+    /// Username or handle.
+    #[serde(default)]
+    pub username: Option<String>,
+    /// Password (for cookie-based auth like X/Twitter).
+    #[serde(default)]
+    pub password: Option<String>,
+    /// Email (for verification flows).
+    #[serde(default)]
+    pub email: Option<String>,
+    /// OAuth access token (for API-based auth like LinkedIn).
+    #[serde(default)]
+    pub access_token: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
 pub struct AgentSocialAccountsConfig {
-    /// X/Twitter credentials for headless social automation.
+    /// X/Twitter credentials for headless social automation (legacy field).
     #[serde(default)]
     pub twitter: Option<SocialTwitterCredentials>,
+    /// Named social accounts keyed by user-chosen label.
+    /// Supports multiple accounts per platform and any platform type.
+    /// Example: `{ "brand-x" = { platform = "twitter", ... }, "corp-linkedin" = { platform = "linkedin", ... } }`
+    #[serde(default)]
+    pub accounts: HashMap<String, SocialAccountConfig>,
 }
 
 /// Valid temperature range for all paths (config, CLI, env override).

--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -23,6 +23,8 @@ const MASKED_SECRET: &str = "***MASKED***";
 pub struct AgentSocialAccountEntry {
     pub agent_name: String,
     pub twitter: Option<crate::config::schema::SocialTwitterCredentials>,
+    #[serde(default)]
+    pub linkedin_accounts: Vec<crate::config::schema::SocialAccountConfig>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -83,6 +85,7 @@ pub struct HeadlessIntegrationStatus {
 pub struct AgentXIntegrationStatus {
     pub agent_name: String,
     pub twitter_x: crate::tools::twitter_mcp::TwitterHealthStatus,
+    pub linkedin: crate::tools::linkedin::LinkedInHealthStatus,
     pub browser_headless: HeadlessIntegrationStatus,
     pub browser_ext: BrowserExtensionIntegrationStatus,
     pub supported_capabilities: IntegrationCapabilityStatus,
@@ -2182,11 +2185,23 @@ fn restore_masked_sensitive_fields(
     }
 }
 
+fn linkedin_accounts_for(
+    social: &crate::config::schema::AgentSocialAccountsConfig,
+) -> Vec<crate::config::schema::SocialAccountConfig> {
+    social
+        .accounts
+        .values()
+        .filter(|a| a.platform == "linkedin")
+        .cloned()
+        .collect()
+}
+
 fn agent_social_accounts_payload(config: &crate::config::Config) -> Vec<AgentSocialAccountEntry> {
     let mut accounts = Vec::new();
     accounts.push(AgentSocialAccountEntry {
         agent_name: "primary".into(),
         twitter: config.agent.social_accounts.twitter.clone(),
+        linkedin_accounts: linkedin_accounts_for(&config.agent.social_accounts),
     });
     let mut delegate_names: Vec<_> = config.agents.keys().cloned().collect();
     delegate_names.sort();
@@ -2195,6 +2210,7 @@ fn agent_social_accounts_payload(config: &crate::config::Config) -> Vec<AgentSoc
             accounts.push(AgentSocialAccountEntry {
                 agent_name: name,
                 twitter: agent.social_accounts.twitter.clone(),
+                linkedin_accounts: linkedin_accounts_for(&agent.social_accounts),
             });
         }
     }
@@ -2239,6 +2255,23 @@ async fn twitter_x_status_for_agent(
             post: false,
             comment: false,
             article: false,
+        },
+    }
+}
+
+#[allow(clippy::unused_async)]
+async fn linkedin_status_for_agent(
+    _agent_name: &str,
+) -> crate::tools::linkedin::LinkedInHealthStatus {
+    // LinkedIn status requires a live API call with credentials; return a static
+    // placeholder for the gateway status endpoint (similar to twitter_x).
+    // The actual health check runs via the `linkedin` tool's `status` action.
+    crate::tools::linkedin::LinkedInHealthStatus {
+        status: "unchecked".into(),
+        detail: Some("Use the linkedin tool with action=status for a live check.".into()),
+        supported_capabilities: crate::tools::linkedin::LinkedInCapabilityMatrix {
+            post: true,
+            comment: true,
         },
     }
 }
@@ -2372,9 +2405,11 @@ async fn x_integration_status_payload(
                         twitter_x_status_for_agent(&agent_name),
                         browser_headless_status_for_agent(config, &agent_name)
                     );
+                    let linkedin = linkedin_status_for_agent(&agent_name).await;
                     AgentXIntegrationStatus {
                         agent_name,
                         twitter_x,
+                        linkedin,
                         browser_headless,
                         browser_ext,
                         supported_capabilities: IntegrationCapabilityStatus {

--- a/src/studio/mod.rs
+++ b/src/studio/mod.rs
@@ -221,6 +221,7 @@ pub fn built_in_classes() -> Vec<AgentClassManifest> {
                 "browser_headless".into(),
                 "browser_ext".into(),
                 "twitter_mcp".into(),
+                "linkedin".into(),
                 "schedule".into(),
                 "memory_recall".into(),
                 "memory_store".into(),

--- a/src/tools/linkedin.rs
+++ b/src/tools/linkedin.rs
@@ -1,0 +1,521 @@
+use super::traits::{Tool, ToolResult};
+use anyhow::anyhow;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::time::Duration;
+
+const LINKEDIN_API_BASE: &str = "https://api.linkedin.com/v2";
+const LINKEDIN_TIMEOUT: Duration = Duration::from_secs(15);
+
+pub struct LinkedInTool;
+
+impl LinkedInTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LinkedInHealthStatus {
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    pub supported_capabilities: LinkedInCapabilityMatrix,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct LinkedInCapabilityMatrix {
+    pub post: bool,
+    pub comment: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedLinkedInCredentials {
+    access_token: String,
+    source: String,
+}
+
+impl LinkedInTool {
+    fn credentials_complete(
+        account: &crate::config::schema::SocialAccountConfig,
+    ) -> Option<String> {
+        let token = account.access_token.as_deref()?.trim();
+        if token.is_empty() {
+            None
+        } else {
+            Some(token.to_string())
+        }
+    }
+
+    async fn resolve_credentials(
+        &self,
+        agent_name: Option<&str>,
+    ) -> anyhow::Result<ResolvedLinkedInCredentials> {
+        // 1. Environment variable
+        if let Ok(token) = std::env::var("LINKEDIN_ACCESS_TOKEN") {
+            if !token.trim().is_empty() {
+                return Ok(ResolvedLinkedInCredentials {
+                    access_token: token,
+                    source: "env".into(),
+                });
+            }
+        }
+
+        let config = crate::config::Config::load_or_init().await?;
+        let target_agent = agent_name
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .unwrap_or("primary");
+        let requested_agent_name = agent_name.map(str::trim).filter(|v| !v.is_empty());
+
+        // Build candidate list from accounts maps
+        let mut candidates: Vec<(String, crate::config::schema::SocialAccountConfig)> = Vec::new();
+
+        // Primary agent's accounts
+        for (label, account) in &config.agent.social_accounts.accounts {
+            if account.platform == "linkedin" {
+                candidates.push((format!("primary:{label}"), account.clone()));
+            }
+        }
+
+        // Delegate agents' accounts
+        let mut delegate_names: Vec<_> = config.agents.keys().cloned().collect();
+        delegate_names.sort();
+        for name in delegate_names {
+            if let Some(agent) = config.agents.get(&name) {
+                for (label, account) in &agent.social_accounts.accounts {
+                    if account.platform == "linkedin" {
+                        candidates.push((format!("{name}:{label}"), account.clone()));
+                    }
+                }
+            }
+        }
+
+        // Match by agent name prefix
+        for (profile_name, account) in &candidates {
+            let agent_part = profile_name.split(':').next().unwrap_or("");
+            if agent_part == target_agent || profile_name == target_agent {
+                if let Some(token) = Self::credentials_complete(account) {
+                    return Ok(ResolvedLinkedInCredentials {
+                        access_token: token,
+                        source: format!("agent:{profile_name}"),
+                    });
+                }
+                if requested_agent_name.is_some() {
+                    return Err(anyhow!(
+                        "linkedin credentials for agent '{}' are incomplete. An access_token is required.",
+                        target_agent
+                    ));
+                }
+                break;
+            }
+        }
+
+        // Fallback: first complete credential
+        let complete: Vec<_> = candidates
+            .iter()
+            .filter_map(|(name, account)| {
+                Self::credentials_complete(account).map(|token| ResolvedLinkedInCredentials {
+                    access_token: token,
+                    source: format!("agent:{name}:only-complete-profile"),
+                })
+            })
+            .collect();
+        if complete.len() == 1 {
+            return Ok(complete[0].clone());
+        }
+
+        Err(anyhow!(
+            "linkedin requires an access_token for agent or label '{}'. Save LinkedIn credentials in config under social_accounts.accounts with platform = \"linkedin\".",
+            target_agent
+        ))
+    }
+
+    async fn api_request(
+        &self,
+        method: &str,
+        path: &str,
+        token: &str,
+        body: Option<Value>,
+    ) -> anyhow::Result<Value> {
+        let client = reqwest::Client::builder()
+            .timeout(LINKEDIN_TIMEOUT)
+            .build()?;
+
+        let url = format!("{LINKEDIN_API_BASE}{path}");
+        let mut req = match method {
+            "GET" => client.get(&url),
+            "POST" => client.post(&url),
+            "DELETE" => client.delete(&url),
+            _ => return Err(anyhow!("Unsupported HTTP method: {method}")),
+        };
+
+        req = req
+            .header("Authorization", format!("Bearer {token}"))
+            .header("X-Restli-Protocol-Version", "2.0.0")
+            .header("LinkedIn-Version", "202401");
+
+        if let Some(body) = body {
+            req = req.header("Content-Type", "application/json").json(&body);
+        }
+
+        let resp = req.send().await?;
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+
+        if !status.is_success() {
+            return Err(anyhow!(
+                "LinkedIn API returned {} for {} {}: {}",
+                status,
+                method,
+                path,
+                text
+            ));
+        }
+
+        if text.is_empty() {
+            Ok(json!({"success": true}))
+        } else {
+            serde_json::from_str(&text)
+                .map_err(|e| anyhow!("Failed to parse LinkedIn response: {e}: {text}"))
+        }
+    }
+
+    async fn health_result(&self, agent_name: Option<&str>) -> anyhow::Result<ToolResult> {
+        match self.resolve_credentials(agent_name).await {
+            Ok(creds) => {
+                match self
+                    .api_request("GET", "/me", &creds.access_token, None)
+                    .await
+                {
+                    Ok(profile) => {
+                        let name = format!(
+                            "{} {}",
+                            profile
+                                .get("localizedFirstName")
+                                .and_then(Value::as_str)
+                                .unwrap_or(""),
+                            profile
+                                .get("localizedLastName")
+                                .and_then(Value::as_str)
+                                .unwrap_or("")
+                        )
+                        .trim()
+                        .to_string();
+                        Ok(ToolResult {
+                            success: true,
+                            output: serde_json::to_string_pretty(&LinkedInHealthStatus {
+                                status: "ready".into(),
+                                detail: Some(format!(
+                                    "Authenticated as {name} (source: {})",
+                                    creds.source
+                                )),
+                                supported_capabilities: LinkedInCapabilityMatrix {
+                                    post: true,
+                                    comment: true,
+                                },
+                            })?,
+                            error: None,
+                            metadata: None,
+                        })
+                    }
+                    Err(e) => Ok(ToolResult {
+                        success: false,
+                        output: serde_json::to_string_pretty(&LinkedInHealthStatus {
+                            status: "auth_failed".into(),
+                            detail: Some(format!("Token validation failed: {e}")),
+                            supported_capabilities: LinkedInCapabilityMatrix {
+                                post: false,
+                                comment: false,
+                            },
+                        })?,
+                        error: None,
+                        metadata: None,
+                    }),
+                }
+            }
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: serde_json::to_string_pretty(&LinkedInHealthStatus {
+                    status: "credentials_missing".into(),
+                    detail: Some(e.to_string()),
+                    supported_capabilities: LinkedInCapabilityMatrix {
+                        post: false,
+                        comment: false,
+                    },
+                })?,
+                error: None,
+                metadata: None,
+            }),
+        }
+    }
+
+    async fn execute_action(
+        &self,
+        action: &str,
+        args: &Value,
+        creds: &ResolvedLinkedInCredentials,
+    ) -> anyhow::Result<ToolResult> {
+        let result = match action {
+            "my_profile" => self.api_request("GET", "/me", &creds.access_token, None).await?,
+
+            "get_profile" => {
+                let vanity = args
+                    .get("vanity_name")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("Missing vanity_name"))?;
+                self.api_request(
+                    "GET",
+                    &format!(
+                        "/people/(vanityName:{})",
+                        urlencoding::encode(vanity)
+                    ),
+                    &creds.access_token,
+                    None,
+                )
+                .await?
+            }
+
+            "publish_post" => {
+                let text = args
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("Missing text"))?;
+
+                // Get the author URN from /me
+                let me = self
+                    .api_request("GET", "/me", &creds.access_token, None)
+                    .await?;
+                let person_id = me
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("Could not resolve person ID from /me"))?;
+                let author = format!("urn:li:person:{person_id}");
+
+                let share_commentary = json!({"text": text});
+
+                let specific_content =
+                    if let Some(url) = args.get("link_url").and_then(Value::as_str) {
+                        json!({
+                            "com.linkedin.ugc.ShareContent": {
+                                "shareCommentary": share_commentary,
+                                "shareMediaCategory": "ARTICLE",
+                                "media": [{
+                                    "status": "READY",
+                                    "originalUrl": url,
+                                    "title": {
+                                        "text": args.get("link_title").and_then(Value::as_str).unwrap_or(url)
+                                    }
+                                }]
+                            }
+                        })
+                    } else {
+                        json!({
+                            "com.linkedin.ugc.ShareContent": {
+                                "shareCommentary": share_commentary,
+                                "shareMediaCategory": "NONE"
+                            }
+                        })
+                    };
+
+                let body = json!({
+                    "author": author,
+                    "lifecycleState": "PUBLISHED",
+                    "specificContent": specific_content,
+                    "visibility": {
+                        "com.linkedin.ugc.MemberNetworkVisibility": args
+                            .get("visibility")
+                            .and_then(Value::as_str)
+                            .unwrap_or("PUBLIC")
+                    }
+                });
+
+                self.api_request("POST", "/ugcPosts", &creds.access_token, Some(body))
+                    .await?
+            }
+
+            "comment" => {
+                let post_urn = args
+                    .get("post_urn")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("Missing post_urn"))?;
+                let text = args
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("Missing text"))?;
+
+                let me = self
+                    .api_request("GET", "/me", &creds.access_token, None)
+                    .await?;
+                let person_id = me
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("Could not resolve person ID from /me"))?;
+
+                let body = json!({
+                    "actor": format!("urn:li:person:{person_id}"),
+                    "message": {
+                        "text": text
+                    }
+                });
+
+                let encoded_urn = urlencoding::encode(post_urn);
+                self.api_request(
+                    "POST",
+                    &format!("/socialActions/{encoded_urn}/comments"),
+                    &creds.access_token,
+                    Some(body),
+                )
+                .await?
+            }
+
+            "get_post" => {
+                let post_urn = args
+                    .get("post_urn")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("Missing post_urn"))?;
+                let encoded = urlencoding::encode(post_urn);
+                self.api_request(
+                    "GET",
+                    &format!("/ugcPosts/{encoded}"),
+                    &creds.access_token,
+                    None,
+                )
+                .await?
+            }
+
+            "get_feed" => {
+                let count = args
+                    .get("count")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(10);
+                self.api_request(
+                    "GET",
+                    &format!("/ugcPosts?q=authors&authors=List()&count={count}"),
+                    &creds.access_token,
+                    None,
+                )
+                .await?
+            }
+
+            other => {
+                return Err(anyhow!(
+                    "Unknown action '{}'. Use one of: status, my_profile, get_profile, publish_post, comment, get_post, get_feed",
+                    other
+                ))
+            }
+        };
+
+        let output = serde_json::to_string_pretty(&result)?;
+        Ok(ToolResult {
+            success: true,
+            output,
+            error: None,
+            metadata: None,
+        })
+    }
+}
+
+#[async_trait]
+impl Tool for LinkedInTool {
+    fn name(&self) -> &str {
+        "linkedin"
+    }
+
+    fn description(&self) -> &str {
+        "LinkedIn adapter for posting, commenting, and profile lookup via the LinkedIn API. Use this for LinkedIn social media management. Credentials come from environment variables (LINKEDIN_ACCESS_TOKEN) or from saved social accounts in config with platform = \"linkedin\"."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "status",
+                        "my_profile",
+                        "get_profile",
+                        "publish_post",
+                        "comment",
+                        "get_post",
+                        "get_feed"
+                    ]
+                },
+                "agent_name": {
+                    "type": "string",
+                    "description": "Optional agent whose saved LinkedIn credentials should be used. Defaults to 'primary'."
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Text content for posts or comments."
+                },
+                "vanity_name": {
+                    "type": "string",
+                    "description": "LinkedIn vanity name (URL slug) for profile lookup."
+                },
+                "post_urn": {
+                    "type": "string",
+                    "description": "LinkedIn post URN (e.g. urn:li:share:12345) for comments or post lookup."
+                },
+                "link_url": {
+                    "type": "string",
+                    "description": "URL to attach to a post as an article link."
+                },
+                "link_title": {
+                    "type": "string",
+                    "description": "Title for the attached link."
+                },
+                "visibility": {
+                    "type": "string",
+                    "enum": ["PUBLIC", "CONNECTIONS"],
+                    "description": "Post visibility. Defaults to PUBLIC."
+                },
+                "count": {
+                    "type": "integer",
+                    "description": "Number of items to retrieve for feed queries."
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let action = args
+            .get("action")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("Missing required field: action"))?;
+        let agent_name = args.get("agent_name").and_then(Value::as_str);
+
+        if action == "status" {
+            return self.health_result(agent_name).await;
+        }
+
+        let creds = self.resolve_credentials(agent_name).await?;
+        self.execute_action(action, &args, &creds).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_includes_publish_post() {
+        let tool = LinkedInTool::new();
+        let schema = tool.parameters_schema();
+        let actions = schema["properties"]["action"]["enum"]
+            .as_array()
+            .expect("enum array");
+        assert!(actions.iter().any(|v| v == "publish_post"));
+        assert!(actions.iter().any(|v| v == "comment"));
+        assert!(actions.iter().any(|v| v == "get_feed"));
+    }
+
+    #[test]
+    fn tool_name_is_linkedin() {
+        let tool = LinkedInTool::new();
+        assert_eq!(tool.name(), "linkedin");
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -42,6 +42,7 @@ pub mod hardware_memory_map;
 pub mod hardware_memory_read;
 pub mod http_request;
 pub mod image_info;
+pub mod linkedin;
 pub mod mail;
 pub mod memory_forget;
 pub mod memory_recall;
@@ -93,6 +94,7 @@ pub use hardware_memory_map::HardwareMemoryMapTool;
 pub use hardware_memory_read::HardwareMemoryReadTool;
 pub use http_request::HttpRequestTool;
 pub use image_info::ImageInfoTool;
+pub use linkedin::LinkedInTool;
 pub use mail::MailTool;
 pub use memory_forget::MemoryForgetTool;
 pub use memory_recall::MemoryRecallTool;
@@ -368,6 +370,46 @@ pub fn all_tools_with_runtime(
                 composio_entity_id,
                 security.clone(),
             )));
+        }
+    }
+
+    // Register twitter_x tool when any agent has Twitter credentials
+    {
+        let has_twitter = root_config.agent.social_accounts.twitter.is_some()
+            || root_config
+                .agent
+                .social_accounts
+                .accounts
+                .values()
+                .any(|a| a.platform == "twitter")
+            || agents.values().any(|a| {
+                a.social_accounts.twitter.is_some()
+                    || a.social_accounts
+                        .accounts
+                        .values()
+                        .any(|sa| sa.platform == "twitter")
+            });
+        if has_twitter {
+            tool_arcs.push(Arc::new(TwitterMcpTool::new()));
+        }
+    }
+
+    // Register linkedin tool when any agent has LinkedIn credentials
+    {
+        let has_linkedin = root_config
+            .agent
+            .social_accounts
+            .accounts
+            .values()
+            .any(|a| a.platform == "linkedin")
+            || agents.values().any(|a| {
+                a.social_accounts
+                    .accounts
+                    .values()
+                    .any(|sa| sa.platform == "linkedin")
+            });
+        if has_linkedin {
+            tool_arcs.push(Arc::new(LinkedInTool::new()));
         }
     }
 

--- a/src/tools/twitter_mcp.rs
+++ b/src/tools/twitter_mcp.rs
@@ -975,15 +975,45 @@ impl TwitterMcpTool {
         if let Some(creds) = config.agent.social_accounts.twitter.clone() {
             candidates.push(("primary".into(), creds));
         }
+        // Also check the generic accounts map for platform == "twitter"
+        for (label, account) in &config.agent.social_accounts.accounts {
+            if account.platform == "twitter" {
+                candidates.push((
+                    format!("primary:{label}"),
+                    crate::config::schema::SocialTwitterCredentials {
+                        username: account.username.clone(),
+                        password: account.password.clone(),
+                        email: account.email.clone(),
+                    },
+                ));
+            }
+        }
         let mut delegate_names: Vec<_> = config.agents.keys().cloned().collect();
         delegate_names.sort();
-        for name in delegate_names {
+        for name in &delegate_names {
             if let Some(creds) = config
                 .agents
-                .get(&name)
+                .get(name)
                 .and_then(|agent| agent.social_accounts.twitter.clone())
             {
-                candidates.push((name, creds));
+                candidates.push((name.clone(), creds));
+            }
+        }
+        // Also check delegate agents' generic accounts maps
+        for name in &delegate_names {
+            if let Some(agent) = config.agents.get(name) {
+                for (label, account) in &agent.social_accounts.accounts {
+                    if account.platform == "twitter" {
+                        candidates.push((
+                            format!("{name}:{label}"),
+                            crate::config::schema::SocialTwitterCredentials {
+                                username: account.username.clone(),
+                                password: account.password.clone(),
+                                email: account.email.clone(),
+                            },
+                        ));
+                    }
+                }
             }
         }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,12 +1,20 @@
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import { useState, useEffect, createContext, useContext } from 'react';
-import Layout from './components/layout/Layout';
 import { ShellProvider, useShell } from './components/shell/ShellProvider';
 import UpdateController from './components/shell/UpdateController';
 import badgeArt from './assets/agent-hq-badge.svg';
-import Dashboard from './pages/Dashboard';
+import { AgentProvider, useAgentContext } from './contexts/AgentContext';
+import { AuthProvider, useAuth } from './hooks/useAuth';
+import { setLocale, type Locale } from './lib/i18n';
+
+// Pages
+import AgentSelector from './pages/AgentSelector';
+import AgentCreationWizard from './pages/AgentCreationWizard';
+import AgentDashboard from './pages/AgentDashboard';
 import AgentChat from './pages/AgentChat';
-import Studio from './pages/Studio';
+import AgentAutomations from './pages/AgentAutomations';
+import AgentSettings from './pages/AgentSettings';
+import SocialAccounts from './pages/SocialAccounts';
 import Tools from './pages/Tools';
 import Cron from './pages/Cron';
 import Integrations from './pages/Integrations';
@@ -15,13 +23,14 @@ import Config from './pages/Config';
 import Cost from './pages/Cost';
 import Logs from './pages/Logs';
 import Doctor from './pages/Doctor';
-// Agent HQ pages
 import Soul from './pages/Soul';
 import Missions from './pages/Missions';
 import Plugins from './pages/Plugins';
 import Sessions from './pages/Sessions';
-import { AuthProvider, useAuth } from './hooks/useAuth';
-import { setLocale, type Locale } from './lib/i18n';
+
+// Layouts
+import AgentScopedLayout from './components/layout/AgentScopedLayout';
+import GlobalLayout from './components/layout/GlobalLayout';
 
 // Locale context
 interface LocaleContextType {
@@ -127,6 +136,24 @@ function PairingDialog({ onPair }: { onPair: (code: string) => Promise<void> }) 
   );
 }
 
+/**
+ * Redirects `/` based on agent count:
+ * - 0 agents → /setup (wizard)
+ * - 1+ agents → /agents (selector)
+ */
+function StartupRedirector() {
+  const { agents, loading } = useAgentContext();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!loading) {
+      navigate(agents.length === 0 ? '/setup' : '/agents', { replace: true });
+    }
+  }, [loading, agents.length, navigate]);
+
+  return null;
+}
+
 function AppContent() {
   const { isAuthenticated, loading, pair, logout } = useAuth();
   const [locale, setLocaleState] = useState('tr');
@@ -168,29 +195,130 @@ function AppContent() {
 
   return (
     <LocaleContext.Provider value={{ locale, setAppLocale }}>
-      <Routes>
-        <Route element={<Layout />}>
-          <Route path="/" element={<Studio />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/agent" element={<AgentChat />} />
-          <Route path="/tools" element={<Tools />} />
-          <Route path="/cron" element={<Cron />} />
-          <Route path="/integrations" element={<Integrations />} />
-          <Route path="/memory" element={<Memory />} />
-          <Route path="/config" element={<Config />} />
-          <Route path="/cost" element={<Cost />} />
-          <Route path="/logs" element={<Logs />} />
-          <Route path="/doctor" element={<Doctor />} />
-          {/* Agent HQ routes */}
-          <Route path="/soul" element={<Soul />} />
-          <Route path="/missions" element={<Missions />} />
-          <Route path="/plugins" element={<Plugins />} />
-          <Route path="/sessions" element={<Sessions />} />
+      <AgentProvider>
+        <Routes>
+          {/* Root redirect based on agent count */}
+          <Route path="/" element={<StartupRedirector />} />
+
+          {/* Agent selector (fullscreen, no sidebar) */}
+          <Route path="/agents" element={<AgentSelectorWrapper />} />
+
+          {/* Agent creation wizard (fullscreen) */}
+          <Route path="/setup" element={<AgentCreationWizardWrapper />} />
+
+          {/* Agent-scoped routes */}
+          <Route path="/agents/:agentId" element={<AgentScopedLayout />}>
+            <Route index element={<AgentDashboard />} />
+            <Route path="chat" element={<AgentChat />} />
+            <Route path="missions" element={<Missions />} />
+            <Route path="sessions" element={<Sessions />} />
+            <Route path="automations" element={<AgentAutomations />} />
+            <Route path="tools" element={<Tools />} />
+            <Route path="memory" element={<Memory />} />
+            <Route path="social-accounts" element={<SocialAccounts />} />
+            <Route path="settings" element={<AgentSettings />} />
+            <Route path="soul" element={<Soul />} />
+          </Route>
+
+          {/* Global routes */}
+          <Route element={<GlobalLayout />}>
+            <Route path="/automations" element={<Cron />} />
+            <Route path="/integrations" element={<Integrations />} />
+            <Route path="/plugins" element={<Plugins />} />
+            <Route path="/settings" element={<Config />} />
+            <Route path="/cost" element={<Cost />} />
+            <Route path="/logs" element={<Logs />} />
+            <Route path="/doctor" element={<Doctor />} />
+          </Route>
+
+          {/* Legacy redirects — old flat routes to new structure */}
+          <Route path="/dashboard" element={<LegacyRedirect to="/" />} />
+          <Route path="/agent" element={<LegacyRedirect to="/chat" />} />
+          <Route path="/cron" element={<Navigate to="/automations" replace />} />
+          <Route path="/config" element={<Navigate to="/settings" replace />} />
+          <Route path="/soul" element={<LegacyRedirect to="/soul" />} />
+          <Route path="/missions" element={<LegacyRedirect to="/missions" />} />
+          <Route path="/sessions" element={<LegacyRedirect to="/sessions" />} />
+          <Route path="/tools" element={<LegacyRedirect to="/tools" />} />
+          <Route path="/memory" element={<LegacyRedirect to="/memory" />} />
+
           <Route path="*" element={<Navigate to="/" replace />} />
-        </Route>
-      </Routes>
+        </Routes>
+      </AgentProvider>
     </LocaleContext.Provider>
   );
+}
+
+/** Wraps AgentSelector in its own shell layout (fullscreen with mac chrome) */
+function AgentSelectorWrapper() {
+  const { isDesktopMac } = useShell();
+
+  if (isDesktopMac) {
+    return (
+      <div className="mac-shell">
+        <div className="mac-content" style={{ marginLeft: 0 }}>
+          <main className="mac-main">
+            <div className="mac-main-scroll">
+              <AgentSelector />
+            </div>
+          </main>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white">
+      <main className="max-w-6xl mx-auto px-6 py-8">
+        <AgentSelector />
+      </main>
+    </div>
+  );
+}
+
+/** Wraps AgentCreationWizard similarly */
+function AgentCreationWizardWrapper() {
+  const { isDesktopMac } = useShell();
+
+  if (isDesktopMac) {
+    return (
+      <div className="mac-shell">
+        <div className="mac-content" style={{ marginLeft: 0 }}>
+          <main className="mac-main">
+            <div className="mac-main-scroll">
+              <AgentCreationWizard />
+            </div>
+          </main>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white">
+      <main className="max-w-6xl mx-auto px-6 py-8">
+        <AgentCreationWizard />
+      </main>
+    </div>
+  );
+}
+
+/**
+ * Legacy redirect: maps old flat routes (e.g. /dashboard, /agent) to agent-scoped routes.
+ * Uses the active agent ID from context.
+ */
+function LegacyRedirect({ to }: { to: string }) {
+  const { activeAgentId, loading } = useAgentContext();
+
+  if (loading) return null;
+
+  if (!activeAgentId) {
+    return <Navigate to="/agents" replace />;
+  }
+
+  // `to` is relative (e.g. "/chat" → "/agents/{id}/chat", "/" → "/agents/{id}")
+  const target = to === '/' ? `/agents/${activeAgentId}` : `/agents/${activeAgentId}${to}`;
+  return <Navigate to={target} replace />;
 }
 
 export default function App() {

--- a/web/src/components/layout/AgentScopedLayout.tsx
+++ b/web/src/components/layout/AgentScopedLayout.tsx
@@ -1,0 +1,274 @@
+import { useEffect } from 'react';
+import { NavLink, Outlet, useNavigate, useParams, useLocation } from 'react-router-dom';
+import { ArrowLeft, PanelLeft } from 'lucide-react';
+import { useAgentContext } from '@/contexts/AgentContext';
+import { useShell } from '@/components/shell/ShellProvider';
+import { getAgentNavSections, type NavSection } from './navigation';
+import { MacBadge } from '@/components/macos/MacPrimitives';
+import socialMediaManagerArt from '@/assets/class-social-media-manager.png';
+import salesArt from '@/assets/class-sales.png';
+import vaArt from '@/assets/class-va.png';
+
+function classArtwork(classId: string): string | null {
+  switch (classId) {
+    case 'social_media_manager':
+      return socialMediaManagerArt;
+    case 'sales':
+      return salesArt;
+    case 'va':
+      return vaArt;
+    default:
+      return null;
+  }
+}
+
+function AgentScopedSidebar({ sections, agentName, agentClass, agentEmoji }: {
+  sections: NavSection[];
+  agentName: string;
+  agentClass: string;
+  agentEmoji: string;
+}) {
+  const navigate = useNavigate();
+  const artwork = classArtwork(agentClass);
+
+  return (
+    <aside className="fixed top-0 left-0 h-screen w-60 bg-gray-900 flex flex-col border-r border-gray-800">
+      {/* Back + Agent identity */}
+      <div className="px-4 py-4 border-b border-gray-800">
+        <button
+          type="button"
+          onClick={() => navigate('/agents')}
+          className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-white transition-colors mb-3"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          All Agents
+        </button>
+        <div className="flex items-center gap-3">
+          {artwork ? (
+            <img src={artwork} alt={agentName} className="h-10 w-10 rounded-xl object-contain" />
+          ) : (
+            <div className="h-10 w-10 rounded-xl bg-gray-800 flex items-center justify-center text-lg">
+              {agentEmoji}
+            </div>
+          )}
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-white truncate">{agentName}</p>
+            <p className="text-[10px] text-gray-500 truncate">{agentClass.replace(/_/g, ' ')}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Navigation */}
+      <nav className="flex-1 overflow-y-auto py-4 px-3 space-y-1">
+        {sections.map((section) => (
+          <div key={section.title}>
+            <div className="pt-4 pb-2 px-3">
+              <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                {section.title}
+              </span>
+            </div>
+            {section.items.map(({ to, icon: Icon, title }) => (
+              <NavLink
+                key={to}
+                to={to}
+                end={to.endsWith(`/agents/`) || !to.includes('/', to.lastIndexOf('/agents/') + 9)}
+                className={({ isActive }) =>
+                  [
+                    'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors',
+                    isActive
+                      ? 'bg-blue-600 text-white'
+                      : 'text-gray-300 hover:bg-gray-800 hover:text-white',
+                  ].join(' ')
+                }
+              >
+                <Icon className="h-5 w-5 flex-shrink-0" />
+                <span>{title}</span>
+              </NavLink>
+            ))}
+          </div>
+        ))}
+      </nav>
+
+      {/* Quick global links */}
+      <div className="px-4 py-3 border-t border-gray-800">
+        <div className="flex gap-2">
+          <NavLink to="/settings" className="text-xs text-gray-500 hover:text-gray-300 transition-colors">
+            Settings
+          </NavLink>
+          <NavLink to="/cost" className="text-xs text-gray-500 hover:text-gray-300 transition-colors">
+            Cost
+          </NavLink>
+          <NavLink to="/logs" className="text-xs text-gray-500 hover:text-gray-300 transition-colors">
+            Logs
+          </NavLink>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function MacAgentScopedSidebar({ sections, agentName, agentClass, agentEmoji, sidebarOpen }: {
+  sections: NavSection[];
+  agentName: string;
+  agentClass: string;
+  agentEmoji: string;
+  sidebarOpen: boolean;
+}) {
+  const navigate = useNavigate();
+  const artwork = classArtwork(agentClass);
+
+  return (
+    <aside className={sidebarOpen ? 'mac-sidebar' : 'mac-sidebar mac-sidebar-collapsed'}>
+      <div className="mac-sidebar-brand" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: '0.5rem' }}>
+        <button
+          type="button"
+          onClick={() => navigate('/agents')}
+          className="flex items-center gap-1.5 text-[0.7rem] opacity-60 hover:opacity-100 transition-opacity"
+          style={{ color: 'var(--shell-muted)' }}
+        >
+          <ArrowLeft className="h-3 w-3" />
+          {sidebarOpen ? 'All Agents' : null}
+        </button>
+        <div className="flex items-center gap-2.5">
+          {artwork ? (
+            <img src={artwork} alt={agentName} className="h-8 w-8 rounded-[10px] object-contain" />
+          ) : (
+            <span className="text-lg">{agentEmoji}</span>
+          )}
+          {sidebarOpen ? (
+            <div>
+              <p className="mac-sidebar-brand-title">{agentName}</p>
+              <p className="mac-sidebar-brand-detail">{agentClass.replace(/_/g, ' ')}</p>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <nav className="mac-sidebar-nav">
+        {sections.map((section) => (
+          <div key={section.title} className="mac-sidebar-section">
+            {sidebarOpen ? <p className="mac-sidebar-section-title">{section.title}</p> : null}
+            <div className="mac-sidebar-items">
+              {section.items.map(({ to, icon: Icon, title }) => (
+                <NavLink
+                  key={to}
+                  to={to}
+                  end={!to.includes('/', to.lastIndexOf('/agents/') + 9)}
+                  className={({ isActive }) =>
+                    [
+                      'mac-sidebar-link',
+                      isActive ? 'mac-sidebar-link-active' : '',
+                      sidebarOpen ? '' : 'mac-sidebar-link-icon-only',
+                    ].join(' ')
+                  }
+                  title={title}
+                >
+                  <Icon className="h-4 w-4" />
+                  {sidebarOpen ? <span>{title}</span> : null}
+                </NavLink>
+              ))}
+            </div>
+          </div>
+        ))}
+      </nav>
+    </aside>
+  );
+}
+
+export default function AgentScopedLayout() {
+  const { agentId } = useParams<{ agentId: string }>();
+  const { agents, setScopedAgent, loading } = useAgentContext();
+  const { isDesktopMac, sidebarOpen, toggleSidebar } = useShell();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const agent = agents.find((a) => a.profile.id === agentId) ?? null;
+
+  useEffect(() => {
+    setScopedAgent(agent);
+    return () => setScopedAgent(null);
+  }, [agent, setScopedAgent]);
+
+  // Redirect if agent not found (after loading completes)
+  useEffect(() => {
+    if (!loading && !agent && agentId) {
+      navigate('/agents', { replace: true });
+    }
+  }, [loading, agent, agentId, navigate]);
+
+  if (loading || !agent) {
+    return null;
+  }
+
+  const sections = getAgentNavSections(agent.profile.id, agent.profile.primary_class);
+
+  // Derive page title from current path
+  const pathSuffix = location.pathname.replace(`/agents/${agentId}`, '') || '/';
+  const currentItem = sections.flatMap((s) => s.items).find((item) => {
+    const itemSuffix = item.to.replace(`/agents/${agentId}`, '') || '/';
+    return itemSuffix === pathSuffix;
+  });
+  const pageTitle = currentItem?.title ?? agent.profile.name;
+
+  if (isDesktopMac) {
+    return (
+      <div className="mac-shell">
+        <MacAgentScopedSidebar
+          sections={sections}
+          agentName={agent.profile.name}
+          agentClass={agent.profile.primary_class}
+          agentEmoji={agent.identity.emoji}
+          sidebarOpen={sidebarOpen}
+        />
+        <div className="mac-content">
+          <header className="mac-toolbar">
+            <div className="mac-toolbar-leading">
+              <button
+                type="button"
+                onClick={toggleSidebar}
+                className="mac-toolbar-button"
+                aria-label="Toggle sidebar"
+              >
+                <PanelLeft className="h-4 w-4" />
+              </button>
+              <div className="mac-toolbar-titles" data-tauri-drag-region>
+                <p className="mac-toolbar-overline">{agent.identity.role_title}</p>
+                <h1 className="mac-toolbar-title">{pageTitle}</h1>
+              </div>
+            </div>
+            <div className="mac-toolbar-trailing">
+              <MacBadge tone="accent">{agent.profile.primary_class.replace(/_/g, ' ')}</MacBadge>
+            </div>
+          </header>
+          <main className="mac-main">
+            <div className="mac-main-scroll">
+              <Outlet />
+            </div>
+          </main>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white">
+      <AgentScopedSidebar
+        sections={sections}
+        agentName={agent.profile.name}
+        agentClass={agent.profile.primary_class}
+        agentEmoji={agent.identity.emoji}
+      />
+      <div className="ml-60 flex flex-col min-h-screen">
+        <header className="sticky top-0 z-10 flex items-center justify-between h-14 px-6 border-b border-gray-800 bg-gray-950/80 backdrop-blur">
+          <div>
+            <p className="text-[10px] text-gray-500 uppercase tracking-wider">{agent.identity.role_title}</p>
+            <h1 className="text-sm font-semibold text-white">{pageTitle}</h1>
+          </div>
+        </header>
+        <main className="flex-1 overflow-y-auto">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/layout/GlobalLayout.tsx
+++ b/web/src/components/layout/GlobalLayout.tsx
@@ -1,0 +1,187 @@
+import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { ArrowLeft, PanelLeft } from 'lucide-react';
+import { useShell } from '@/components/shell/ShellProvider';
+import { globalNavSections } from './navigation';
+import badgeArt from '@/assets/agent-hq-badge.svg';
+
+function GlobalSidebar() {
+  const navigate = useNavigate();
+
+  return (
+    <aside className="fixed top-0 left-0 h-screen w-60 bg-gray-900 flex flex-col border-r border-gray-800">
+      {/* Logo + back to agents */}
+      <div className="px-4 py-4 border-b border-gray-800">
+        <button
+          type="button"
+          onClick={() => navigate('/agents')}
+          className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-white transition-colors mb-3"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Agents
+        </button>
+        <div className="flex items-center gap-2">
+          <div className="h-8 w-8 rounded-lg bg-blue-600 flex items-center justify-center text-white font-bold text-sm">
+            HQ
+          </div>
+          <div className="flex flex-col">
+            <span className="text-lg font-semibold text-white tracking-wide leading-tight">
+              Agent HQ
+            </span>
+            <span className="text-[10px] text-gray-500 leading-tight">
+              Global Settings
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Navigation */}
+      <nav className="flex-1 overflow-y-auto py-4 px-3 space-y-1">
+        {globalNavSections.map((section) => (
+          <div key={section.title}>
+            <div className="pt-4 pb-2 px-3">
+              <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                {section.title}
+              </span>
+            </div>
+            {section.items.map(({ to, icon: Icon, title }) => (
+              <NavLink
+                key={to}
+                to={to}
+                className={({ isActive }) =>
+                  [
+                    'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors',
+                    isActive
+                      ? 'bg-blue-600 text-white'
+                      : 'text-gray-300 hover:bg-gray-800 hover:text-white',
+                  ].join(' ')
+                }
+              >
+                <Icon className="h-5 w-5 flex-shrink-0" />
+                <span>{title}</span>
+              </NavLink>
+            ))}
+          </div>
+        ))}
+      </nav>
+    </aside>
+  );
+}
+
+function MacGlobalSidebar({ sidebarOpen }: { sidebarOpen: boolean }) {
+  const navigate = useNavigate();
+
+  return (
+    <aside className={sidebarOpen ? 'mac-sidebar' : 'mac-sidebar mac-sidebar-collapsed'}>
+      <div className="mac-sidebar-brand" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: '0.5rem' }}>
+        <button
+          type="button"
+          onClick={() => navigate('/agents')}
+          className="flex items-center gap-1.5 text-[0.7rem] opacity-60 hover:opacity-100 transition-opacity"
+          style={{ color: 'var(--shell-muted)' }}
+        >
+          <ArrowLeft className="h-3 w-3" />
+          {sidebarOpen ? 'Agents' : null}
+        </button>
+        <div className="flex items-center gap-2.5">
+          <img src={badgeArt} alt="Agent HQ" className="h-8 w-8" />
+          {sidebarOpen ? (
+            <div>
+              <p className="mac-sidebar-brand-title">Agent HQ</p>
+              <p className="mac-sidebar-brand-detail">Global settings &amp; operations</p>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <nav className="mac-sidebar-nav">
+        {globalNavSections.map((section) => (
+          <div key={section.title} className="mac-sidebar-section">
+            {sidebarOpen ? <p className="mac-sidebar-section-title">{section.title}</p> : null}
+            <div className="mac-sidebar-items">
+              {section.items.map(({ to, icon: Icon, title }) => (
+                <NavLink
+                  key={to}
+                  to={to}
+                  className={({ isActive }) =>
+                    [
+                      'mac-sidebar-link',
+                      isActive ? 'mac-sidebar-link-active' : '',
+                      sidebarOpen ? '' : 'mac-sidebar-link-icon-only',
+                    ].join(' ')
+                  }
+                  title={title}
+                >
+                  <Icon className="h-4 w-4" />
+                  {sidebarOpen ? <span>{title}</span> : null}
+                </NavLink>
+              ))}
+            </div>
+          </div>
+        ))}
+      </nav>
+    </aside>
+  );
+}
+
+export default function GlobalLayout() {
+  const location = useLocation();
+  const { isDesktopMac, sidebarOpen, toggleSidebar } = useShell();
+  const titleMap: Record<string, string> = {
+    '/automations': 'All Automations',
+    '/integrations': 'Integrations',
+    '/plugins': 'Plugins',
+    '/settings': 'Settings',
+    '/cost': 'Cost',
+    '/logs': 'Logs',
+    '/doctor': 'Doctor',
+  };
+  const pageTitle = titleMap[location.pathname] ?? 'Agent HQ';
+
+  if (isDesktopMac) {
+    return (
+      <div className="mac-shell">
+        <MacGlobalSidebar sidebarOpen={sidebarOpen} />
+        <div className="mac-content">
+          <header className="mac-toolbar">
+            <div className="mac-toolbar-leading">
+              <button
+                type="button"
+                onClick={toggleSidebar}
+                className="mac-toolbar-button"
+                aria-label="Toggle sidebar"
+              >
+                <PanelLeft className="h-4 w-4" />
+              </button>
+              <div className="mac-toolbar-titles" data-tauri-drag-region>
+                <p className="mac-toolbar-overline">Global</p>
+                <h1 className="mac-toolbar-title">{pageTitle}</h1>
+              </div>
+            </div>
+          </header>
+          <main className="mac-main">
+            <div className="mac-main-scroll">
+              <Outlet />
+            </div>
+          </main>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white">
+      <GlobalSidebar />
+      <div className="ml-60 flex flex-col min-h-screen">
+        <header className="sticky top-0 z-10 flex items-center h-14 px-6 border-b border-gray-800 bg-gray-950/80 backdrop-blur">
+          <div>
+            <p className="text-[10px] text-gray-500 uppercase tracking-wider">Global</p>
+            <h1 className="text-sm font-semibold text-white">{pageTitle}</h1>
+          </div>
+        </header>
+        <main className="flex-1 overflow-y-auto">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/layout/navigation.ts
+++ b/web/src/components/layout/navigation.ts
@@ -9,6 +9,7 @@ import {
   Package,
   Puzzle,
   Settings,
+  Share2,
   Sparkles,
   Stethoscope,
   Target,
@@ -26,6 +27,72 @@ export interface NavSection {
   title: string;
   items: NavItem[];
 }
+
+// ---------------------------------------------------------------------------
+// Agent-scoped navigation (shown inside /agents/:agentId/*)
+// ---------------------------------------------------------------------------
+
+export function getAgentNavSections(agentId: string, agentClass?: string): NavSection[] {
+  const base = `/agents/${agentId}`;
+  const sections: NavSection[] = [
+    {
+      title: 'Agent',
+      items: [
+        { to: base, icon: LayoutDashboard, title: 'Dashboard' },
+        { to: `${base}/chat`, icon: MessageSquare, title: 'Chat' },
+        { to: `${base}/missions`, icon: Target, title: 'Missions' },
+        { to: `${base}/sessions`, icon: Users, title: 'Sessions' },
+      ],
+    },
+    {
+      title: 'Operations',
+      items: [
+        { to: `${base}/automations`, icon: Clock, title: 'Automations' },
+        { to: `${base}/tools`, icon: Wrench, title: 'Tools' },
+        { to: `${base}/memory`, icon: Brain, title: 'Memory' },
+        ...(agentClass === 'social_media_manager'
+          ? [{ to: `${base}/social-accounts`, icon: Share2, title: 'Social Accounts' }]
+          : []),
+      ],
+    },
+    {
+      title: 'Agent Config',
+      items: [
+        { to: `${base}/settings`, icon: Settings, title: 'Settings' },
+        { to: `${base}/soul`, icon: Sparkles, title: 'Soul' },
+      ],
+    },
+  ];
+  return sections;
+}
+
+// ---------------------------------------------------------------------------
+// Global navigation (shown outside agent scope)
+// ---------------------------------------------------------------------------
+
+export const globalNavSections: NavSection[] = [
+  {
+    title: 'Overview',
+    items: [
+      { to: '/automations', icon: Clock, title: 'All Automations' },
+      { to: '/integrations', icon: Puzzle, title: 'Integrations' },
+      { to: '/plugins', icon: Package, title: 'Plugins' },
+    ],
+  },
+  {
+    title: 'System',
+    items: [
+      { to: '/settings', icon: Settings, title: 'Settings' },
+      { to: '/cost', icon: DollarSign, title: 'Cost' },
+      { to: '/logs', icon: Activity, title: 'Logs' },
+      { to: '/doctor', icon: Stethoscope, title: 'Doctor' },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Legacy flat nav (kept for backward-compat with command palette actions)
+// ---------------------------------------------------------------------------
 
 export const primaryNavSections: NavSection[] = [
   {
@@ -62,12 +129,12 @@ export const primaryNavSections: NavSection[] = [
 
 export const navItems = primaryNavSections.flatMap((section) => section.items);
 
-export const routeTitles = Object.fromEntries(
+export const routeTitles: Record<string, string> = Object.fromEntries(
   navItems.map((item) => [item.to, item.title]),
-) as Record<string, string>;
+);
 
 export const menuActionRoutes: Record<string, string> = {
-  'navigate.studio': '/',
+  'navigate.studio': '/agents',
   'navigate.dashboard': '/dashboard',
   'navigate.agent': '/agent',
   'navigate.missions': '/missions',
@@ -76,9 +143,9 @@ export const menuActionRoutes: Record<string, string> = {
   'navigate.memory': '/memory',
   'navigate.logs': '/logs',
   'navigate.cost': '/cost',
-  'app.preferences': '/config',
+  'app.preferences': '/settings',
   'help.diagnostics': '/doctor',
-  'file.new_agent': '/?new=1',
+  'file.new_agent': '/setup',
   'file.new_mission': '/missions?new=1',
   'file.new_session': '/sessions?new=1',
 };

--- a/web/src/contexts/AgentContext.tsx
+++ b/web/src/contexts/AgentContext.tsx
@@ -1,0 +1,75 @@
+import { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import type { ResolvedAgentProfile } from '@/types/api';
+import { getAgents, activateAgent as apiActivateAgent } from '@/lib/api';
+
+interface AgentContextType {
+  agents: ResolvedAgentProfile[];
+  activeAgentId: string;
+  /** The agent being viewed in the scoped layout (from URL param). */
+  scopedAgent: ResolvedAgentProfile | null;
+  setScopedAgent: (agent: ResolvedAgentProfile | null) => void;
+  activateAgent: (id: string) => Promise<void>;
+  refreshAgents: () => Promise<void>;
+  loading: boolean;
+}
+
+const AgentContext = createContext<AgentContextType>({
+  agents: [],
+  activeAgentId: '',
+  scopedAgent: null,
+  setScopedAgent: () => {},
+  activateAgent: async () => {},
+  refreshAgents: async () => {},
+  loading: true,
+});
+
+export function AgentProvider({ children }: { children: React.ReactNode }) {
+  const [agents, setAgents] = useState<ResolvedAgentProfile[]>([]);
+  const [activeAgentId, setActiveAgentId] = useState('');
+  const [scopedAgent, setScopedAgent] = useState<ResolvedAgentProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refreshAgents = useCallback(async () => {
+    try {
+      const data = await getAgents();
+      setAgents(data.profiles);
+      setActiveAgentId(data.active_agent_id);
+    } catch {
+      // silently fail — auth might not be ready yet
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshAgents();
+  }, [refreshAgents]);
+
+  const activateAgent = useCallback(
+    async (id: string) => {
+      await apiActivateAgent(id);
+      await refreshAgents();
+    },
+    [refreshAgents],
+  );
+
+  return (
+    <AgentContext.Provider
+      value={{
+        agents,
+        activeAgentId,
+        scopedAgent,
+        setScopedAgent,
+        activateAgent,
+        refreshAgents,
+        loading,
+      }}
+    >
+      {children}
+    </AgentContext.Provider>
+  );
+}
+
+export function useAgentContext() {
+  return useContext(AgentContext);
+}

--- a/web/src/pages/AgentAutomations.tsx
+++ b/web/src/pages/AgentAutomations.tsx
@@ -1,0 +1,12 @@
+import { useAgentContext } from '@/contexts/AgentContext';
+import Cron from './Cron';
+
+/**
+ * Agent-scoped automation view.
+ * Renders the standard Cron page but pre-scoped to the current agent.
+ */
+export default function AgentAutomations() {
+  const { scopedAgent } = useAgentContext();
+  // Pass the scoped agent ID as a prop so Cron can pre-filter
+  return <Cron ownerAgentFilter={scopedAgent?.profile.id ?? undefined} />;
+}

--- a/web/src/pages/AgentCreationWizard.tsx
+++ b/web/src/pages/AgentCreationWizard.tsx
@@ -1,0 +1,330 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, ArrowRight, Sparkles } from 'lucide-react';
+import {
+  completeOnboarding,
+  createAgent,
+  getClasses,
+} from '@/lib/api';
+import { useAgentContext } from '@/contexts/AgentContext';
+import {
+  MacBadge,
+  MacEmptyState,
+  MacPage,
+  MacPanel,
+  MacStat,
+} from '@/components/macos/MacPrimitives';
+import { useShell } from '@/components/shell/ShellProvider';
+import socialMediaManagerArt from '@/assets/class-social-media-manager.png';
+import salesArt from '@/assets/class-sales.png';
+import vaArt from '@/assets/class-va.png';
+import type { AgentClassManifest, AgentProfile } from '@/types/api';
+
+function classArtwork(classId: string): string | null {
+  switch (classId) {
+    case 'social_media_manager':
+      return socialMediaManagerArt;
+    case 'sales':
+      return salesArt;
+    case 'va':
+      return vaArt;
+    default:
+      return null;
+  }
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 40);
+}
+
+function defaultProfile(): AgentProfile {
+  return {
+    id: 'agent',
+    name: 'Agent',
+    avatar: 'local operator',
+    launch_on_startup: false,
+    primary_class: 'va',
+    social_accounts: {},
+    overrides: {
+      summary: 'Handle practical work across the workspace with reliable follow-through.',
+      system_prompt_appendix: '',
+      provider: null,
+      model: null,
+      temperature: null,
+      max_depth: null,
+      agentic: true,
+      max_iterations: null,
+      tool_grants: [],
+      skill_grants: [],
+      soul: { voice: '', principles: [], boundaries: [], style: null },
+      identity: {},
+    },
+  };
+}
+
+function panelFieldClass(isDesktopMac: boolean): string {
+  return isDesktopMac
+    ? 'mt-2 w-full rounded-[1rem] border border-[rgba(15,23,42,0.08)] bg-white/80 px-4 py-3 text-[0.97rem] text-slate-900 outline-none shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] focus:border-sky-400 dark:border-white/10 dark:bg-black/20 dark:text-white'
+    : 'mt-2 w-full rounded-[1rem] border border-white/10 bg-[#0b1120] px-4 py-3 text-[0.97rem] text-white outline-none focus:border-sky-400';
+}
+
+function actionButtonClass(primary: boolean, isDesktopMac: boolean): string {
+  if (primary) {
+    return isDesktopMac
+      ? 'inline-flex items-center gap-2 rounded-full bg-[#0a84ff] px-5 py-2.5 text-sm font-semibold text-white shadow-[0_12px_24px_rgba(10,132,255,0.22)] transition hover:brightness-105'
+      : 'inline-flex items-center gap-2 rounded-full bg-sky-500 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-sky-400';
+  }
+  return isDesktopMac
+    ? 'inline-flex items-center gap-2 rounded-full border border-[rgba(15,23,42,0.08)] bg-white/70 px-5 py-2.5 text-sm font-semibold text-slate-800 transition hover:bg-white dark:border-white/10 dark:bg-white/6 dark:text-white'
+    : 'inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-white/10';
+}
+
+function ClassChoiceCard({
+  classItem,
+  selected,
+  disabled,
+  onClick,
+}: {
+  classItem: AgentClassManifest;
+  selected: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={[
+        'flex items-start gap-4 rounded-[1.25rem] border px-4 py-4 text-left transition',
+        selected
+          ? 'border-sky-400/50 bg-sky-500/10'
+          : 'border-[var(--shell-border)] bg-[var(--shell-panel)] hover:bg-[var(--shell-selection)]',
+        disabled ? 'cursor-not-allowed opacity-55' : '',
+      ].join(' ')}
+    >
+      {classArtwork(classItem.id) ? (
+        <img
+          src={classArtwork(classItem.id) ?? undefined}
+          alt={classItem.name}
+          className="h-16 w-16 shrink-0 rounded-[1rem] object-contain p-2 studio-art-frame"
+        />
+      ) : (
+        <div className="h-16 w-16 shrink-0 rounded-[1rem] bg-[var(--shell-selection)]" />
+      )}
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-semibold">{classItem.name}</h3>
+          <MacBadge tone={classItem.status === 'coming_soon' ? 'neutral' : 'accent'}>
+            {classItem.status === 'coming_soon' ? 'Soon' : 'Ready'}
+          </MacBadge>
+        </div>
+        <p className="mt-2 text-sm text-[var(--shell-muted)]">{classItem.description}</p>
+        <p className="mt-2 text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">
+          {classItem.fantasy_theme}
+        </p>
+      </div>
+    </button>
+  );
+}
+
+export default function AgentCreationWizard() {
+  const { isDesktopMac } = useShell();
+  const navigate = useNavigate();
+  const { refreshAgents } = useAgentContext();
+  const [classes, setClasses] = useState<AgentClassManifest[]>([]);
+  const [draft, setDraft] = useState<AgentProfile>(defaultProfile());
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loadingClasses, setLoadingClasses] = useState(true);
+
+  useEffect(() => {
+    getClasses()
+      .then(setClasses)
+      .catch(() => {})
+      .finally(() => setLoadingClasses(false));
+  }, []);
+
+  const wizardClassPreview = useMemo(
+    () =>
+      [draft.primary_class]
+        .map((id) => classes.find((item) => item.id === id))
+        .filter(Boolean) as AgentClassManifest[],
+    [classes, draft.primary_class],
+  );
+
+  const handleCreate = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const prepared: AgentProfile = {
+        ...draft,
+        id: slugify(draft.id || draft.name) || 'new_agent',
+      };
+      const created = await createAgent(prepared, true);
+      await completeOnboarding(created.profile.id);
+      await refreshAgents();
+      navigate(`/agents/${created.profile.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create agent');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loadingClasses) {
+    return (
+      <MacPage eyebrow="Setup" title="Loading..." description="Fetching agent classes.">
+        <MacPanel title="Starting up">
+          <MacEmptyState
+            icon={<Sparkles className="h-8 w-8 animate-pulse" />}
+            title="Loading classes"
+            description="Preparing the agent creation flow."
+          />
+        </MacPanel>
+      </MacPage>
+    );
+  }
+
+  return (
+    <MacPage
+      eyebrow="Setup"
+      title="Create an Agent"
+      description="Set up identity, class loadout, and startup behavior in one focused pass."
+    >
+      {error ? (
+        <div className="rounded-[1.4rem] border border-rose-300/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-700 dark:text-rose-200 mb-4">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 xl:grid-cols-[1.15fr_0.85fr]">
+        <MacPanel title="Agent identity" detail="Name, role summary, and one primary class.">
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="block text-sm">
+              <span className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">
+                Agent name
+              </span>
+              <input
+                value={draft.name}
+                onChange={(e) =>
+                  setDraft((prev) => ({
+                    ...prev,
+                    name: e.target.value,
+                    id: slugify(e.target.value) || prev.id,
+                  }))
+                }
+                className={panelFieldClass(isDesktopMac)}
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">
+                Agent id
+              </span>
+              <input
+                value={draft.id}
+                onChange={(e) => setDraft((prev) => ({ ...prev, id: slugify(e.target.value) }))}
+                className={panelFieldClass(isDesktopMac)}
+              />
+            </label>
+          </div>
+
+          <label className="mt-4 block text-sm">
+            <span className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">
+              Role summary
+            </span>
+            <textarea
+              rows={4}
+              value={draft.overrides.summary ?? ''}
+              onChange={(e) =>
+                setDraft((prev) => ({
+                  ...prev,
+                  overrides: { ...prev.overrides, summary: e.target.value },
+                }))
+              }
+              className={panelFieldClass(isDesktopMac)}
+            />
+          </label>
+
+          <div className="mt-6">
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-semibold">Primary class</h3>
+              <MacBadge tone="accent">Required</MacBadge>
+            </div>
+            <div className="mt-3 grid gap-3">
+              {classes.map((classItem) => (
+                <ClassChoiceCard
+                  key={classItem.id}
+                  classItem={classItem}
+                  selected={draft.primary_class === classItem.id}
+                  disabled={classItem.status === 'coming_soon'}
+                  onClick={() => setDraft((prev) => ({ ...prev, primary_class: classItem.id }))}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={handleCreate}
+              className={[actionButtonClass(true, isDesktopMac), busy ? 'opacity-60' : ''].join(' ')}
+            >
+              {busy ? 'Creating agent...' : 'Finish Setup'}
+              <ArrowRight className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate('/agents')}
+              className={actionButtonClass(false, isDesktopMac)}
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Cancel
+            </button>
+          </div>
+        </MacPanel>
+
+        <div className="grid gap-4">
+          <MacPanel title="Live preview" detail="Summary of the agent being created.">
+            <div className="grid gap-3">
+              <MacStat
+                label="Primary"
+                value={classes.find((item) => item.id === draft.primary_class)?.name ?? 'Unassigned'}
+                detail="Default decision-making lens"
+              />
+            </div>
+            <div className="mt-4 rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] p-4">
+              <p className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">
+                Soul voice blend
+              </p>
+              <p className="mt-2 text-sm text-[var(--shell-muted)]">
+                {wizardClassPreview
+                  .map((item) => item.default_soul_overlay.voice)
+                  .filter(Boolean)
+                  .join(' / ') || 'Base voice'}
+              </p>
+            </div>
+            <div className="mt-4 rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] p-4">
+              <p className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">
+                Tool grants
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {Array.from(new Set(wizardClassPreview.flatMap((item) => item.tool_grants)))
+                  .slice(0, 8)
+                  .map((tool) => (
+                    <MacBadge key={tool} tone="neutral">{tool}</MacBadge>
+                  ))}
+              </div>
+            </div>
+          </MacPanel>
+        </div>
+      </div>
+    </MacPage>
+  );
+}

--- a/web/src/pages/AgentDashboard.tsx
+++ b/web/src/pages/AgentDashboard.tsx
@@ -1,0 +1,35 @@
+import { useAgentContext } from '@/contexts/AgentContext';
+import SocialMediaManagerDashboard from './dashboards/SocialMediaManagerDashboard';
+import SalesDashboard from './dashboards/SalesDashboard';
+import VADashboard from './dashboards/VADashboard';
+import { MacEmptyState, MacPage, MacPanel } from '@/components/macos/MacPrimitives';
+import { Sparkles } from 'lucide-react';
+
+export default function AgentDashboard() {
+  const { scopedAgent } = useAgentContext();
+
+  if (!scopedAgent) {
+    return (
+      <MacPage eyebrow="Dashboard" title="No agent selected" description="">
+        <MacPanel title="Agent not found">
+          <MacEmptyState
+            icon={<Sparkles className="h-8 w-8" />}
+            title="No agent"
+            description="Select an agent from the roster to view their dashboard."
+          />
+        </MacPanel>
+      </MacPage>
+    );
+  }
+
+  switch (scopedAgent.profile.primary_class) {
+    case 'social_media_manager':
+      return <SocialMediaManagerDashboard agent={scopedAgent} />;
+    case 'sales':
+      return <SalesDashboard agent={scopedAgent} />;
+    case 'va':
+      return <VADashboard agent={scopedAgent} />;
+    default:
+      return <VADashboard agent={scopedAgent} />;
+  }
+}

--- a/web/src/pages/AgentSelector.tsx
+++ b/web/src/pages/AgentSelector.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Plus, Search } from 'lucide-react';
+import { useAgentContext } from '@/contexts/AgentContext';
+import { useShell } from '@/components/shell/ShellProvider';
+import { MacBadge, MacPage, MacSearchField, MacEmptyState } from '@/components/macos/MacPrimitives';
+import socialMediaManagerArt from '@/assets/class-social-media-manager.png';
+import salesArt from '@/assets/class-sales.png';
+import vaArt from '@/assets/class-va.png';
+import type { ResolvedAgentProfile } from '@/types/api';
+
+function classArtwork(classId: string): string | null {
+  switch (classId) {
+    case 'social_media_manager':
+      return socialMediaManagerArt;
+    case 'sales':
+      return salesArt;
+    case 'va':
+      return vaArt;
+    default:
+      return null;
+  }
+}
+
+function AgentCard({
+  agent,
+  isActive,
+  onClick,
+  isDesktopMac,
+}: {
+  agent: ResolvedAgentProfile;
+  isActive: boolean;
+  onClick: () => void;
+  isDesktopMac: boolean;
+}) {
+  const artwork = classArtwork(agent.profile.primary_class);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        'group flex items-start gap-4 rounded-[1.25rem] border p-5 text-left transition',
+        isActive
+          ? 'border-sky-400/50 bg-sky-500/10'
+          : isDesktopMac
+            ? 'border-[var(--shell-border)] bg-[var(--shell-panel)] hover:bg-[var(--shell-selection)]'
+            : 'border-gray-800 bg-gray-900 hover:bg-gray-800',
+      ].join(' ')}
+    >
+      {artwork ? (
+        <img
+          src={artwork}
+          alt={agent.profile.name}
+          className="h-16 w-16 shrink-0 rounded-[1rem] object-contain p-1 studio-art-frame"
+        />
+      ) : (
+        <div className={`h-16 w-16 shrink-0 rounded-[1rem] flex items-center justify-center text-2xl ${isDesktopMac ? 'bg-[var(--shell-selection)]' : 'bg-gray-800'}`}>
+          {agent.identity.emoji}
+        </div>
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className={`text-base font-semibold ${isDesktopMac ? '' : 'text-white'}`}>{agent.profile.name}</h3>
+          {isActive ? <MacBadge tone="accent">Active</MacBadge> : null}
+        </div>
+        <p className={`mt-0.5 text-xs uppercase tracking-wider ${isDesktopMac ? 'text-[var(--shell-muted)]' : 'text-gray-500'}`}>
+          {agent.identity.role_title}
+        </p>
+        <p className={`mt-2 text-sm line-clamp-2 ${isDesktopMac ? 'text-[var(--shell-muted)]' : 'text-gray-400'}`}>
+          {agent.summary}
+        </p>
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {agent.classes.map((c) => (
+            <MacBadge key={c.id} tone="neutral">{c.name}</MacBadge>
+          ))}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+export default function AgentSelector() {
+  const { agents, activeAgentId, loading } = useAgentContext();
+  const { isDesktopMac } = useShell();
+  const navigate = useNavigate();
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return agents;
+    return agents.filter((a) => {
+      const haystack = [
+        a.profile.name,
+        a.summary,
+        a.identity.role_title,
+        ...a.classes.map((c) => c.name),
+      ].join(' ').toLowerCase();
+      return haystack.includes(normalized);
+    });
+  }, [agents, query]);
+
+  if (loading) {
+    return (
+      <MacPage
+        eyebrow="Agent HQ"
+        title="Loading agents..."
+        description="Fetching your agent roster."
+      >
+        <div />
+      </MacPage>
+    );
+  }
+
+  return (
+    <MacPage
+      eyebrow="Agent HQ"
+      title="Choose an Agent"
+      description="Select an agent to enter its workspace, or create a new one."
+    >
+      <div className="flex items-center gap-3 mb-6">
+        <div className="flex-1">
+          <MacSearchField
+            value={query}
+            onChange={setQuery}
+            placeholder="Search agents, roles, and classes"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => navigate('/setup')}
+          className={
+            isDesktopMac
+              ? 'inline-flex items-center gap-2 rounded-full bg-[#0a84ff] px-5 py-2.5 text-sm font-semibold text-white shadow-[0_12px_24px_rgba(10,132,255,0.22)] transition hover:brightness-105'
+              : 'inline-flex items-center gap-2 rounded-full bg-sky-500 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-sky-400'
+          }
+        >
+          <Plus className="h-4 w-4" />
+          New Agent
+        </button>
+      </div>
+
+      {filtered.length === 0 && agents.length === 0 ? (
+        <MacEmptyState
+          icon={<Plus className="h-8 w-8" />}
+          title="No agents yet"
+          description="Create your first agent to get started."
+        />
+      ) : filtered.length === 0 ? (
+        <MacEmptyState
+          icon={<Search className="h-7 w-7" />}
+          title="No matching agents"
+          description="Try a different search term."
+        />
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {filtered.map((agent) => (
+            <AgentCard
+              key={agent.profile.id}
+              agent={agent}
+              isActive={agent.profile.id === activeAgentId}
+              onClick={() => navigate(`/agents/${agent.profile.id}`)}
+              isDesktopMac={isDesktopMac}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Global shortcuts */}
+      <div className={`mt-8 flex flex-wrap gap-3 pt-6 border-t ${isDesktopMac ? 'border-[var(--shell-border)]' : 'border-gray-800'}`}>
+        <button
+          type="button"
+          onClick={() => navigate('/automations')}
+          className={`text-sm ${isDesktopMac ? 'text-[var(--shell-muted)] hover:text-[var(--shell-fg)]' : 'text-gray-500 hover:text-gray-300'} transition-colors`}
+        >
+          All Automations
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate('/settings')}
+          className={`text-sm ${isDesktopMac ? 'text-[var(--shell-muted)] hover:text-[var(--shell-fg)]' : 'text-gray-500 hover:text-gray-300'} transition-colors`}
+        >
+          Global Settings
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate('/cost')}
+          className={`text-sm ${isDesktopMac ? 'text-[var(--shell-muted)] hover:text-[var(--shell-fg)]' : 'text-gray-500 hover:text-gray-300'} transition-colors`}
+        >
+          Cost
+        </button>
+      </div>
+    </MacPage>
+  );
+}

--- a/web/src/pages/AgentSettings.tsx
+++ b/web/src/pages/AgentSettings.tsx
@@ -1,0 +1,186 @@
+import { useState } from 'react';
+import { Save } from 'lucide-react';
+import { updateAgent } from '@/lib/api';
+import { useAgentContext } from '@/contexts/AgentContext';
+import { useShell } from '@/components/shell/ShellProvider';
+import { MacPage, MacPanel, MacStat } from '@/components/macos/MacPrimitives';
+import type { AgentProfile } from '@/types/api';
+
+export default function AgentSettings() {
+  const { scopedAgent, refreshAgents } = useAgentContext();
+  const { isDesktopMac } = useShell();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [draft, setDraft] = useState<AgentProfile | null>(null);
+
+  if (!scopedAgent) return null;
+
+  const profile = draft ?? scopedAgent.profile;
+
+  const fieldClass = isDesktopMac
+    ? 'mt-1 w-full rounded-[1rem] border border-[rgba(15,23,42,0.08)] bg-white/80 px-4 py-2.5 text-sm text-slate-900 outline-none focus:border-sky-400 dark:border-white/10 dark:bg-black/20 dark:text-white'
+    : 'mt-1 w-full rounded-[1rem] border border-white/10 bg-[#0b1120] px-4 py-2.5 text-sm text-white outline-none focus:border-sky-400';
+
+  const update = (partial: Partial<AgentProfile>) => {
+    setDraft((prev) => ({ ...(prev ?? scopedAgent.profile), ...partial }));
+  };
+
+  const updateOverrides = (partial: Partial<AgentProfile['overrides']>) => {
+    setDraft((prev) => {
+      const base = prev ?? scopedAgent.profile;
+      return { ...base, overrides: { ...base.overrides, ...partial } };
+    });
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      await updateAgent(profile);
+      await refreshAgents();
+      setDraft(null);
+      setSuccess('Agent settings saved.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <MacPage
+      eyebrow={scopedAgent.profile.name}
+      title="Agent Settings"
+      description="Configure identity, model, and behavior overrides."
+    >
+      {error ? (
+        <div className="rounded-[1.4rem] border border-rose-300/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-700 dark:text-rose-200 mb-4">
+          {error}
+        </div>
+      ) : null}
+      {success ? (
+        <div className="rounded-[1.4rem] border border-emerald-300/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-200 mb-4">
+          {success}
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 md:grid-cols-4 mb-4">
+        <MacStat label="Agent ID" value={profile.id} detail="Unique identifier" />
+        <MacStat label="Class" value={scopedAgent.classes[0]?.name ?? 'None'} detail="Primary class" />
+        <MacStat label="Tools" value={String(scopedAgent.tool_grants.length)} detail="Granted tools" />
+        <MacStat label="Startup" value={profile.launch_on_startup ? 'Yes' : 'No'} detail="Auto-launch" />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <MacPanel title="Identity" detail="Name, avatar, and role summary.">
+          <div className="grid gap-4">
+            <label className="block">
+              <span className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">Name</span>
+              <input
+                value={profile.name}
+                onChange={(e) => update({ name: e.target.value })}
+                className={fieldClass}
+              />
+            </label>
+            <label className="block">
+              <span className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">Avatar description</span>
+              <input
+                value={profile.avatar ?? ''}
+                onChange={(e) => update({ avatar: e.target.value })}
+                className={fieldClass}
+              />
+            </label>
+            <label className="block">
+              <span className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">Role summary</span>
+              <textarea
+                rows={4}
+                value={profile.overrides.summary ?? ''}
+                onChange={(e) => updateOverrides({ summary: e.target.value })}
+                className={fieldClass}
+              />
+            </label>
+          </div>
+        </MacPanel>
+
+        <MacPanel title="Model Overrides" detail="Override the global model settings for this agent.">
+          <div className="grid gap-4">
+            <label className="block">
+              <span className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">Provider</span>
+              <input
+                value={profile.overrides.provider ?? ''}
+                onChange={(e) => updateOverrides({ provider: e.target.value || null })}
+                placeholder="Use global default"
+                className={fieldClass}
+              />
+            </label>
+            <label className="block">
+              <span className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">Model</span>
+              <input
+                value={profile.overrides.model ?? ''}
+                onChange={(e) => updateOverrides({ model: e.target.value || null })}
+                placeholder="Use global default"
+                className={fieldClass}
+              />
+            </label>
+            <label className="block">
+              <span className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">Temperature</span>
+              <input
+                type="number"
+                step="0.1"
+                min="0"
+                max="2"
+                value={profile.overrides.temperature ?? ''}
+                onChange={(e) => updateOverrides({ temperature: e.target.value ? Number(e.target.value) : null })}
+                placeholder="Use global default"
+                className={fieldClass}
+              />
+            </label>
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={profile.overrides.agentic ?? false}
+                  onChange={(e) => updateOverrides({ agentic: e.target.checked })}
+                  className="rounded"
+                />
+                Agentic mode
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={profile.launch_on_startup ?? false}
+                  onChange={(e) => update({ launch_on_startup: e.target.checked })}
+                  className="rounded"
+                />
+                Launch on startup
+              </label>
+            </div>
+          </div>
+        </MacPanel>
+      </div>
+
+      <div className="mt-4 flex gap-3">
+        <button
+          type="button"
+          disabled={saving || !draft}
+          onClick={handleSave}
+          className="inline-flex items-center gap-2 rounded-full bg-[#0a84ff] px-5 py-2.5 text-sm font-semibold text-white shadow-[0_12px_24px_rgba(10,132,255,0.22)] transition hover:brightness-105 disabled:opacity-50"
+        >
+          <Save className="h-4 w-4" />
+          {saving ? 'Saving...' : 'Save Changes'}
+        </button>
+        {draft ? (
+          <button
+            type="button"
+            onClick={() => setDraft(null)}
+            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-5 py-2.5 text-sm font-medium transition hover:bg-white/10"
+          >
+            Discard
+          </button>
+        ) : null}
+      </div>
+    </MacPage>
+  );
+}

--- a/web/src/pages/Cron.tsx
+++ b/web/src/pages/Cron.tsx
@@ -304,7 +304,7 @@ function statCard(title: string, value: string, note: string, icon: ReactNode) {
   );
 }
 
-export default function Cron() {
+export default function Cron({ ownerAgentFilter }: { ownerAgentFilter?: string } = {}) {
   const [automations, setAutomations] = useState<AutomationRecord[]>([]);
   const [profiles, setProfiles] = useState<ResolvedAgentProfile[]>([]);
   const [activeAgentId, setActiveAgentId] = useState('');
@@ -315,7 +315,7 @@ export default function Cron() {
   const [form, setForm] = useState<FormState>(emptyForm);
   const [formError, setFormError] = useState<string | null>(null);
   const [typeFilter, setTypeFilter] = useState<'all' | AutomationKind>('all');
-  const [ownerFilter, setOwnerFilter] = useState('all');
+  const [ownerFilter, setOwnerFilter] = useState(ownerAgentFilter ?? 'all');
   const [statusFilter, setStatusFilter] = useState<'all' | 'enabled' | 'disabled' | 'failed'>(
     'all',
   );
@@ -405,7 +405,7 @@ export default function Cron() {
   const openCreate = () => {
     setForm({
       ...emptyForm,
-      owner_agent_id: activeAgentId,
+      owner_agent_id: ownerAgentFilter ?? activeAgentId,
     });
     setFormError(null);
     setShowForm(true);

--- a/web/src/pages/SocialAccounts.tsx
+++ b/web/src/pages/SocialAccounts.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useState } from 'react';
+import {
+  AlertCircle,
+  CheckCircle2,
+  ExternalLink,
+  RefreshCw,
+  Save,
+  Share2,
+} from 'lucide-react';
+import {
+  getAgentSocialAccounts,
+  putAgentSocialAccounts,
+  bootstrapAgentXHeadlessSession,
+} from '@/lib/api';
+import { useAgentContext } from '@/contexts/AgentContext';
+import {
+  MacBadge,
+  MacEmptyState,
+  MacPage,
+  MacPanel,
+} from '@/components/macos/MacPrimitives';
+import { useShell } from '@/components/shell/ShellProvider';
+import type { AgentSocialAccount, AgentXIntegrationStatus } from '@/types/api';
+
+export default function SocialAccounts() {
+  const { scopedAgent, refreshAgents } = useAgentContext();
+  const { isDesktopMac } = useShell();
+  const [accounts, setAccounts] = useState<AgentSocialAccount[]>([]);
+  const [xStatus, setXStatus] = useState<AgentXIntegrationStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [bootstrapping, setBootstrapping] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const agentId = scopedAgent?.profile.id ?? '';
+
+  useEffect(() => {
+    getAgentSocialAccounts()
+      .then((data) => {
+        setAccounts(data.accounts);
+        setXStatus(data.x_status);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Find or create the account entry for this agent
+  const thisAccount = accounts.find((a) => a.agent_name === agentId) ?? {
+    agent_name: agentId,
+    twitter: { username: '', password: '', email: '' },
+  };
+  const thisXStatus = xStatus.find((s) => s.agent_name === agentId);
+
+  const updateTwitterField = (field: 'username' | 'password' | 'email', value: string) => {
+    setAccounts((prev) => {
+      const existing = prev.find((a) => a.agent_name === agentId);
+      if (existing) {
+        return prev.map((a) =>
+          a.agent_name === agentId
+            ? { ...a, twitter: { ...a.twitter, [field]: value } }
+            : a,
+        );
+      }
+      return [...prev, { agent_name: agentId, twitter: { username: '', password: '', email: '', [field]: value } }];
+    });
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const result = await putAgentSocialAccounts(accounts);
+      setAccounts(result.accounts);
+      setXStatus(result.x_status);
+      await refreshAgents();
+      setSuccess('Social accounts saved successfully.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save accounts');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleBootstrap = async (mode: 'headless' | 'interactive' | 'import_chrome') => {
+    setBootstrapping(mode);
+    setError(null);
+    setSuccess(null);
+    try {
+      const result = await bootstrapAgentXHeadlessSession(agentId, mode);
+      if (result.error) {
+        setError(result.error);
+      } else {
+        setSuccess(result.message ?? 'X session bootstrapped successfully.');
+      }
+      const data = await getAgentSocialAccounts();
+      setAccounts(data.accounts);
+      setXStatus(data.x_status);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Bootstrap failed');
+    } finally {
+      setBootstrapping(null);
+    }
+  };
+
+  const fieldClass = isDesktopMac
+    ? 'w-full rounded-[1rem] border border-[rgba(15,23,42,0.08)] bg-white/80 px-4 py-2.5 text-sm text-slate-900 outline-none focus:border-sky-400 dark:border-white/10 dark:bg-black/20 dark:text-white'
+    : 'w-full rounded-[1rem] border border-white/10 bg-[#0b1120] px-4 py-2.5 text-sm text-white outline-none focus:border-sky-400';
+
+  if (!scopedAgent) return null;
+
+  return (
+    <MacPage
+      eyebrow={scopedAgent.profile.name}
+      title="Social Accounts"
+      description="Manage X (Twitter) and LinkedIn connections for this agent."
+    >
+      {error ? (
+        <div className="rounded-[1.4rem] border border-rose-300/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-700 dark:text-rose-200 mb-4">
+          {error}
+        </div>
+      ) : null}
+      {success ? (
+        <div className="rounded-[1.4rem] border border-emerald-300/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-200 mb-4">
+          {success}
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 xl:grid-cols-[1.2fr_0.8fr]">
+        {/* X (Twitter) Credentials */}
+        <MacPanel title="X (Twitter)" detail="Enter credentials for headless login.">
+          <div className="grid gap-4">
+            <label className="block">
+              <span className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">Username / handle</span>
+              <input
+                value={thisAccount.twitter?.username ?? ''}
+                onChange={(e) => updateTwitterField('username', e.target.value)}
+                placeholder="@handle"
+                className={`mt-1 ${fieldClass}`}
+              />
+            </label>
+            <label className="block">
+              <span className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">Email</span>
+              <input
+                value={thisAccount.twitter?.email ?? ''}
+                onChange={(e) => updateTwitterField('email', e.target.value)}
+                placeholder="account@example.com"
+                className={`mt-1 ${fieldClass}`}
+              />
+            </label>
+            <label className="block">
+              <span className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">Password</span>
+              <input
+                type="password"
+                value={thisAccount.twitter?.password ?? ''}
+                onChange={(e) => updateTwitterField('password', e.target.value)}
+                placeholder="password"
+                className={`mt-1 ${fieldClass}`}
+              />
+            </label>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            <button
+              type="button"
+              disabled={saving}
+              onClick={handleSave}
+              className="inline-flex items-center gap-2 rounded-full bg-[#0a84ff] px-4 py-2 text-sm font-medium text-white transition hover:brightness-105 disabled:opacity-50"
+            >
+              <Save className="h-4 w-4" />
+              {saving ? 'Saving...' : 'Save Credentials'}
+            </button>
+          </div>
+        </MacPanel>
+
+        {/* X Session Status */}
+        <MacPanel title="X Session" detail="Authentication and bootstrap status.">
+          {loading ? (
+            <MacEmptyState
+              icon={<RefreshCw className="h-7 w-7 animate-spin" />}
+              title="Loading status"
+              description="Checking X authentication..."
+            />
+          ) : thisXStatus ? (
+            <div className="space-y-4">
+              <div className="flex items-center gap-3">
+                {thisXStatus.browser_headless.authenticated ? (
+                  <CheckCircle2 className="h-6 w-6 text-emerald-400" />
+                ) : (
+                  <AlertCircle className="h-6 w-6 text-amber-400" />
+                )}
+                <div>
+                  <p className="text-sm font-semibold">
+                    {thisXStatus.browser_headless.authenticated ? 'Authenticated' : 'Not authenticated'}
+                  </p>
+                  <p className="text-xs text-[var(--shell-muted)]">
+                    {thisXStatus.browser_headless.detail || thisXStatus.twitter_x.detail || 'No details'}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {thisXStatus.supported_capabilities.post ? <MacBadge tone="accent">Post</MacBadge> : null}
+                {thisXStatus.supported_capabilities.comment ? <MacBadge tone="accent">Reply</MacBadge> : null}
+              </div>
+
+              <div className="grid gap-2">
+                <button
+                  type="button"
+                  disabled={!!bootstrapping}
+                  onClick={() => handleBootstrap('headless')}
+                  className="inline-flex items-center gap-2 rounded-full border border-sky-400/30 bg-sky-500/10 px-4 py-2 text-sm font-medium text-sky-400 transition hover:bg-sky-500/20 disabled:opacity-50"
+                >
+                  {bootstrapping === 'headless' ? <RefreshCw className="h-4 w-4 animate-spin" /> : <ExternalLink className="h-4 w-4" />}
+                  Bootstrap Headless
+                </button>
+                <button
+                  type="button"
+                  disabled={!!bootstrapping}
+                  onClick={() => handleBootstrap('interactive')}
+                  className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium transition hover:bg-white/10 disabled:opacity-50"
+                >
+                  {bootstrapping === 'interactive' ? <RefreshCw className="h-4 w-4 animate-spin" /> : <ExternalLink className="h-4 w-4" />}
+                  Bootstrap Interactive
+                </button>
+                <button
+                  type="button"
+                  disabled={!!bootstrapping}
+                  onClick={() => handleBootstrap('import_chrome')}
+                  className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium transition hover:bg-white/10 disabled:opacity-50"
+                >
+                  {bootstrapping === 'import_chrome' ? <RefreshCw className="h-4 w-4 animate-spin" /> : <Share2 className="h-4 w-4" />}
+                  Import from Chrome
+                </button>
+              </div>
+            </div>
+          ) : (
+            <MacEmptyState
+              icon={<Share2 className="h-7 w-7" />}
+              title="No X status"
+              description="Save credentials first, then bootstrap a session."
+            />
+          )}
+        </MacPanel>
+      </div>
+    </MacPage>
+  );
+}

--- a/web/src/pages/dashboards/SalesDashboard.tsx
+++ b/web/src/pages/dashboards/SalesDashboard.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Briefcase, MessageSquare, Target } from 'lucide-react';
+import { getAutomations } from '@/lib/api';
+import {
+  MacEmptyState,
+  MacPage,
+  MacPanel,
+  MacStat,
+} from '@/components/macos/MacPrimitives';
+import type { AutomationRecord, ResolvedAgentProfile } from '@/types/api';
+
+export default function SalesDashboard({ agent }: { agent: ResolvedAgentProfile }) {
+  const [automations, setAutomations] = useState<AutomationRecord[]>([]);
+  const [, setLoading] = useState(true);
+  const agentId = agent.profile.id;
+
+  useEffect(() => {
+    getAutomations()
+      .then((autos) => setAutomations(autos.filter((a) => a.owner_agent_id === agentId)))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [agentId]);
+
+  return (
+    <MacPage
+      eyebrow={agent.identity.role_title}
+      title={`${agent.profile.name} Dashboard`}
+      description="Sales pipeline, outreach, and call preparation."
+    >
+      <div className="grid gap-4 md:grid-cols-4">
+        <MacStat label="Class" value="Sales" detail={agent.classes.map((c) => c.name).join(', ')} />
+        <MacStat label="Automations" value={String(automations.length)} detail="Scheduled tasks" />
+        <MacStat label="Tools" value={String(agent.tool_grants.length)} detail="Available tools" />
+        <MacStat label="Skills" value={String(agent.skill_grants.length)} detail="Active skills" />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <MacPanel title="Quick Actions" detail="Jump into common sales workflows.">
+          <div className="grid gap-3 md:grid-cols-2">
+            <Link
+              to={`/agents/${agentId}/chat`}
+              className="rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] p-4 transition hover:bg-[var(--shell-selection)]"
+            >
+              <MessageSquare className="h-5 w-5 text-[#0a84ff]" />
+              <h3 className="mt-3 text-sm font-semibold">Agent Chat</h3>
+              <p className="mt-2 text-sm text-[var(--shell-muted)]">
+                Work directly with your sales agent.
+              </p>
+            </Link>
+            <Link
+              to={`/agents/${agentId}/missions`}
+              className="rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] p-4 transition hover:bg-[var(--shell-selection)]"
+            >
+              <Target className="h-5 w-5 text-[#0a84ff]" />
+              <h3 className="mt-3 text-sm font-semibold">Missions</h3>
+              <p className="mt-2 text-sm text-[var(--shell-muted)]">
+                Long-running sales objectives and tasks.
+              </p>
+            </Link>
+          </div>
+        </MacPanel>
+
+        <MacPanel title="Pipeline" detail="Sales pipeline overview.">
+          <MacEmptyState
+            icon={<Briefcase className="h-7 w-7" />}
+            title="Pipeline coming soon"
+            description="CRM integration and pipeline tracking will be available in a future update."
+          />
+        </MacPanel>
+      </div>
+    </MacPage>
+  );
+}

--- a/web/src/pages/dashboards/SocialMediaManagerDashboard.tsx
+++ b/web/src/pages/dashboards/SocialMediaManagerDashboard.tsx
@@ -1,0 +1,282 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock,
+  ExternalLink,
+  Plus,
+  RefreshCw,
+  Share2,
+} from 'lucide-react';
+import {
+  getAgentSocialAccounts,
+  getAutomations,
+  bootstrapAgentXHeadlessSession,
+} from '@/lib/api';
+import {
+  MacBadge,
+  MacEmptyState,
+  MacPage,
+  MacPanel,
+  MacStat,
+} from '@/components/macos/MacPrimitives';
+import type {
+  AgentSocialAccount,
+  AgentXIntegrationStatus,
+  AutomationRecord,
+  ResolvedAgentProfile,
+} from '@/types/api';
+
+export default function SocialMediaManagerDashboard({ agent }: { agent: ResolvedAgentProfile }) {
+  const [socialAccounts, setSocialAccounts] = useState<AgentSocialAccount[]>([]);
+  const [xStatus, setXStatus] = useState<AgentXIntegrationStatus[]>([]);
+  const [automations, setAutomations] = useState<AutomationRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [bootstrapping, setBootstrapping] = useState<string | null>(null);
+
+  const agentId = agent.profile.id;
+
+  useEffect(() => {
+    Promise.all([getAgentSocialAccounts(), getAutomations()])
+      .then(([social, autos]) => {
+        setSocialAccounts(social.accounts);
+        setXStatus(social.x_status);
+        setAutomations(autos.filter((a) => a.owner_agent_id === agentId));
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [agentId]);
+
+  const thisAgentAccounts = socialAccounts.filter((a) => a.agent_name === agentId);
+  const thisAgentXStatus = xStatus.filter((s) => s.agent_name === agentId);
+
+  const activeAutomations = automations.filter((a) => a.enabled);
+  const pausedAutomations = automations.filter((a) => !a.enabled);
+
+  const handleBootstrapX = async (accountAgentName: string) => {
+    setBootstrapping(accountAgentName);
+    try {
+      await bootstrapAgentXHeadlessSession(accountAgentName, 'headless');
+      const social = await getAgentSocialAccounts();
+      setSocialAccounts(social.accounts);
+      setXStatus(social.x_status);
+    } catch {
+      // silently fail — user can retry
+    } finally {
+      setBootstrapping(null);
+    }
+  };
+
+  return (
+    <MacPage
+      eyebrow={agent.identity.role_title}
+      title={`${agent.profile.name} Dashboard`}
+      description="Social media accounts, automations, and content overview."
+    >
+      {/* Stats row */}
+      <div className="grid gap-4 md:grid-cols-4">
+        <MacStat
+          label="Social Accounts"
+          value={String(thisAgentAccounts.length)}
+          detail="Connected platforms"
+        />
+        <MacStat
+          label="Active Automations"
+          value={String(activeAutomations.length)}
+          detail="Scheduled tasks"
+        />
+        <MacStat
+          label="Paused"
+          value={String(pausedAutomations.length)}
+          detail="Inactive automations"
+        />
+        <MacStat
+          label="Class"
+          value="Social Media"
+          detail={agent.classes.map((c) => c.name).join(', ')}
+        />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[1.2fr_0.8fr]">
+        {/* Social Accounts Panel */}
+        <MacPanel
+          title="Social Accounts"
+          detail="Connected X and LinkedIn accounts for this agent."
+        >
+          {loading ? (
+            <MacEmptyState
+              icon={<RefreshCw className="h-7 w-7 animate-spin" />}
+              title="Loading accounts"
+              description="Fetching social account status..."
+            />
+          ) : thisAgentAccounts.length === 0 && thisAgentXStatus.length === 0 ? (
+            <MacEmptyState
+              icon={<Share2 className="h-7 w-7" />}
+              title="No social accounts"
+              description="Add X or LinkedIn accounts in Social Accounts settings."
+            />
+          ) : (
+            <div className="grid gap-3">
+              {/* X accounts from x_status */}
+              {thisAgentXStatus.map((status) => (
+                <div
+                  key={status.agent_name}
+                  className="flex items-start gap-4 rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] p-4"
+                >
+                  <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-black text-white text-lg font-bold shrink-0">
+                    X
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <h4 className="text-sm font-semibold">X (Twitter)</h4>
+                      <MacBadge
+                        tone={
+                          status.browser_headless.authenticated
+                            ? 'accent'
+                            : 'neutral'
+                        }
+                      >
+                        {status.browser_headless.authenticated
+                          ? 'Authenticated'
+                          : 'Not Connected'}
+                      </MacBadge>
+                    </div>
+                    <p className="mt-1 text-sm text-[var(--shell-muted)]">
+                      {status.twitter_x.detail || status.browser_headless.detail || 'No details available'}
+                    </p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {status.supported_capabilities.post ? (
+                        <MacBadge tone="accent">Post</MacBadge>
+                      ) : null}
+                      {status.supported_capabilities.comment ? (
+                        <MacBadge tone="accent">Reply</MacBadge>
+                      ) : null}
+                      {status.supported_capabilities.article ? (
+                        <MacBadge tone="accent">Article</MacBadge>
+                      ) : null}
+                    </div>
+                  </div>
+                  {!status.browser_headless.authenticated ? (
+                    <button
+                      type="button"
+                      disabled={bootstrapping === status.agent_name}
+                      onClick={() => handleBootstrapX(status.agent_name)}
+                      className="inline-flex items-center gap-1.5 rounded-full bg-sky-500/10 border border-sky-400/30 px-3 py-1.5 text-xs font-medium text-sky-400 transition hover:bg-sky-500/20"
+                    >
+                      {bootstrapping === status.agent_name ? (
+                        <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      )}
+                      Connect
+                    </button>
+                  ) : null}
+                </div>
+              ))}
+
+              {/* Twitter credentials from social_accounts */}
+              {thisAgentAccounts
+                .filter((a) => a.twitter?.username)
+                .map((account) => {
+                  const matchingStatus = thisAgentXStatus.find((s) => s.agent_name === account.agent_name);
+                  if (matchingStatus) return null; // already shown above
+                  return (
+                    <div
+                      key={`twitter-${account.agent_name}`}
+                      className="flex items-start gap-4 rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] p-4"
+                    >
+                      <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-black text-white text-lg font-bold shrink-0">
+                        X
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <h4 className="text-sm font-semibold">@{account.twitter?.username}</h4>
+                          <MacBadge tone="neutral">Credentials Only</MacBadge>
+                        </div>
+                        <p className="mt-1 text-sm text-[var(--shell-muted)]">
+                          Session needs to be bootstrapped.
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+            </div>
+          )}
+
+          <div className="mt-4">
+            <Link
+              to={`/agents/${agentId}/social-accounts`}
+              className="inline-flex items-center gap-2 text-sm text-sky-400 hover:text-sky-300 transition-colors"
+            >
+              <Plus className="h-4 w-4" />
+              Manage Social Accounts
+            </Link>
+          </div>
+        </MacPanel>
+
+        {/* Automations Panel */}
+        <MacPanel
+          title="Automations"
+          detail="Scheduled posts, replies, and recurring tasks."
+        >
+          {loading ? (
+            <MacEmptyState
+              icon={<RefreshCw className="h-7 w-7 animate-spin" />}
+              title="Loading automations"
+              description="Fetching scheduled tasks..."
+            />
+          ) : automations.length === 0 ? (
+            <MacEmptyState
+              icon={<Clock className="h-7 w-7" />}
+              title="No automations"
+              description="Create automations for scheduled posts and auto-replies."
+            />
+          ) : (
+            <div className="grid gap-3">
+              {automations.slice(0, 8).map((auto) => (
+                <div
+                  key={auto.id}
+                  className="flex items-start gap-3 rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] px-4 py-3"
+                >
+                  <div className="mt-0.5">
+                    {auto.enabled ? (
+                      <CheckCircle2 className="h-4 w-4 text-emerald-400" />
+                    ) : (
+                      <AlertCircle className="h-4 w-4 text-amber-400" />
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium truncate">
+                      {auto.name || auto.prompt?.slice(0, 60) || 'Untitled'}
+                    </p>
+                    <div className="mt-1 flex items-center gap-2">
+                      <MacBadge tone={auto.enabled ? 'accent' : 'neutral'}>
+                        {auto.enabled ? 'Active' : 'Paused'}
+                      </MacBadge>
+                      {auto.next_run ? (
+                        <span className="text-xs text-[var(--shell-muted)]">
+                          Next: {new Date(auto.next_run).toLocaleString()}
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="mt-4">
+            <Link
+              to={`/agents/${agentId}/automations`}
+              className="inline-flex items-center gap-2 text-sm text-sky-400 hover:text-sky-300 transition-colors"
+            >
+              <Clock className="h-4 w-4" />
+              Manage Automations
+            </Link>
+          </div>
+        </MacPanel>
+      </div>
+    </MacPage>
+  );
+}

--- a/web/src/pages/dashboards/VADashboard.tsx
+++ b/web/src/pages/dashboards/VADashboard.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Brain, Clock, MessageSquare, Target } from 'lucide-react';
+import { getAutomations } from '@/lib/api';
+import {
+  MacPage,
+  MacPanel,
+  MacStat,
+  MacBadge,
+} from '@/components/macos/MacPrimitives';
+import type { AutomationRecord, ResolvedAgentProfile } from '@/types/api';
+
+export default function VADashboard({ agent }: { agent: ResolvedAgentProfile }) {
+  const [automations, setAutomations] = useState<AutomationRecord[]>([]);
+  const [, setLoading] = useState(true);
+  const agentId = agent.profile.id;
+
+  useEffect(() => {
+    getAutomations()
+      .then((autos) => setAutomations(autos.filter((a) => a.owner_agent_id === agentId)))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [agentId]);
+
+  const activeAutomations = automations.filter((a) => a.enabled);
+
+  return (
+    <MacPage
+      eyebrow={agent.identity.role_title}
+      title={`${agent.profile.name} Dashboard`}
+      description="Tasks, inbox triage, and scheduled operations."
+    >
+      <div className="grid gap-4 md:grid-cols-4">
+        <MacStat label="Class" value="VA" detail={agent.classes.map((c) => c.name).join(', ')} />
+        <MacStat label="Automations" value={String(activeAutomations.length)} detail="Active tasks" />
+        <MacStat label="Tools" value={String(agent.tool_grants.length)} detail="Available tools" />
+        <MacStat label="Skills" value={String(agent.skill_grants.length)} detail="Active skills" />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[1fr_1fr]">
+        <MacPanel title="Quick Actions" detail="Jump into common VA workflows.">
+          <div className="grid gap-3 md:grid-cols-2">
+            <Link
+              to={`/agents/${agentId}/chat`}
+              className="rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] p-4 transition hover:bg-[var(--shell-selection)]"
+            >
+              <MessageSquare className="h-5 w-5 text-[#0a84ff]" />
+              <h3 className="mt-3 text-sm font-semibold">Agent Chat</h3>
+              <p className="mt-2 text-sm text-[var(--shell-muted)]">Work directly with your VA.</p>
+            </Link>
+            <Link
+              to={`/agents/${agentId}/missions`}
+              className="rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] p-4 transition hover:bg-[var(--shell-selection)]"
+            >
+              <Target className="h-5 w-5 text-[#0a84ff]" />
+              <h3 className="mt-3 text-sm font-semibold">Missions</h3>
+              <p className="mt-2 text-sm text-[var(--shell-muted)]">Long-running objectives.</p>
+            </Link>
+            <Link
+              to={`/agents/${agentId}/memory`}
+              className="rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] p-4 transition hover:bg-[var(--shell-selection)]"
+            >
+              <Brain className="h-5 w-5 text-[#0a84ff]" />
+              <h3 className="mt-3 text-sm font-semibold">Memory</h3>
+              <p className="mt-2 text-sm text-[var(--shell-muted)]">Agent knowledge base.</p>
+            </Link>
+            <Link
+              to={`/agents/${agentId}/automations`}
+              className="rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] p-4 transition hover:bg-[var(--shell-selection)]"
+            >
+              <Clock className="h-5 w-5 text-[#0a84ff]" />
+              <h3 className="mt-3 text-sm font-semibold">Automations</h3>
+              <p className="mt-2 text-sm text-[var(--shell-muted)]">Scheduled tasks and reminders.</p>
+            </Link>
+          </div>
+        </MacPanel>
+
+        <MacPanel title="Agent Details" detail="Role, guardrails, and tool access.">
+          <div className="space-y-4">
+            <div className="rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] p-4">
+              <p className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">Summary</p>
+              <p className="mt-2 text-sm">{agent.summary}</p>
+            </div>
+            <div className="rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] p-4">
+              <p className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">Guardrails</p>
+              <div className="mt-3 grid gap-2">
+                {agent.guardrails.slice(0, 4).map((g) => (
+                  <div key={g} className="rounded-[1rem] bg-[var(--shell-selection)] px-3 py-2 text-sm">
+                    {g}
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="rounded-[1.25rem] border border-[var(--shell-border)] bg-[var(--shell-panel)] p-4">
+              <p className="text-[0.72rem] uppercase tracking-[0.18em] text-[var(--shell-muted)]">Tool grants</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {agent.tool_grants.slice(0, 8).map((tool) => (
+                  <MacBadge key={tool} tone="neutral">{tool}</MacBadge>
+                ))}
+              </div>
+            </div>
+          </div>
+        </MacPanel>
+      </div>
+    </MacPage>
+  );
+}


### PR DESCRIPTION
## Summary
- Rework both browser and macOS frontends to be agent-centric with agent selector, agent-scoped routes, and class-specific dashboards
- Social Media Manager class gets multi-account panel (X/LinkedIn), automation overview, and session bootstrap UI
- Global views (automations, settings, cost, logs) separated from agent-scoped views
- Fix structural bug: remove `importXSessionFromChrome` fallback in `bootstrapXSession` that silently authenticated as wrong account

## Test plan
- [ ] Verify `/` redirects to `/agents` when agents exist, `/setup` when none
- [ ] Create new agent via wizard at `/setup`, confirm redirect to agent dashboard
- [ ] Navigate between agent-scoped pages (dashboard, chat, automations, settings)
- [ ] Verify Social Media Manager dashboard shows account status and automations
- [ ] Verify global pages (/automations, /settings, /cost) accessible from global sidebar
- [ ] Verify legacy routes (/dashboard, /agent, /cron) redirect correctly
- [ ] Build passes: `cd web && npm run build`
- [ ] macOS desktop app layout renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)